### PR TITLE
Add missing period inside Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ We'll use auto-deployment from TravisCI to GitHub Pages to host our content.
 
 As mentioned above, a major set of goals for the project is to blur the line
 between user and developer, client and server, as well as documentation and source code. To achieve this, a number of philosophies about how the project is
-run will be practiced
+run will be practiced.
 
 Where possible, we favour the contributor over the process.  As much as we can, we will seek to remove barriers to having people contribute, and try to get people involved vs. maintaining some aspirational but impractical level of quality.  If we break something, we'll fix it as we go.  Don't let that stop people from trying.
 


### PR DESCRIPTION
Fixes #2 - Update documentation with a missing period for consistency.

**Before**:

<img width="914" alt="screen shot 2018-04-27 at 10 44 13 pm" src="https://user-images.githubusercontent.com/13009507/39391161-3ec2554e-4a6d-11e8-9a31-b77f4e73b310.png">


**After**:

<img width="910" alt="screen shot 2018-04-27 at 10 49 15 pm" src="https://user-images.githubusercontent.com/13009507/39391168-5c7bea82-4a6d-11e8-96cc-443cb61eef34.png">