### PR TITLE
Support for prettier code formatting on modified files ONLY.

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,25 @@
+{
+    "tabWidth": 4,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "overrides": [
+        {
+            "files": "*.ts",
+            "options": {
+                "parser": "typescript"
+            }
+        },
+        {
+            "files": "*.md",
+            "options": {
+                "parser": "markdown"
+            }
+        },
+        {
+            "files": "*.json",
+            "options": {
+                "parser": "json"
+            }
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "unbundled",
+  "version": "0.0.1",
+  "description": "This is an attempt at unbundling the web.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "precommit": "precise-commits"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/humphd/next.git"
+  },
+  "author": "David Humphrey",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/humphd/next/issues"
+  },
+  "homepage": "https://github.com/humphd/next#readme",
+  "devDependencies": {
+    "husky": "^0.14.3",
+    "precise-commits": "^1.0.2",
+    "prettier": "^1.12.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "precommit": "precise-commits"
+    "precommit": "precise-commits --whitelist=\"**/!(*.json)\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Addressing #7. Opting for small PRs that only have code related to the feature instead of bulky PRs that have changes + formatted file.

**NOTE**: if there are any files that were formatted, they are __NOT__ appended to the underlining commit. Instead, it is dev's job to commit changes separately. This is mainly done to avoid confusion on why code looks different and where new commits are coming from.

Check out [precise-commits](https://www.npmjs.com/package/precise-commits) and Prettier docs [recommendations](https://prettier.io/docs/en/precommit.html#option-4-precise-commits-https-githubcom-jameshenry-precise-commits)