### PR TITLE
Modified Travis build directory from website/build to website/build/next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ deploy:
   keep-history: false
   on:
     branch: master
-  local-dir: website/build
+  local-dir: website/build/Next


### PR DESCRIPTION
This is a simple modification in the Travis build script to fix something we missed in #35.
Removing the `Next` directory.

```bash
Next/blog/2018/05/09/new-version-1.0.0.html |   8 +++
 Next/blog/atom.xml                          |  24 +++++++
 Next/blog/feed.xml                          |  25 +++++++
 Next/blog/index.html                        |   8 +++
 Next/css/main.css                           |   1 +
 Next/docs/architecture.html                 | 100 ++++++++++++++++++++++++++++
 Next/docs/community.html                    |  12 ++++
 Next/docs/introduction.html                 |  56 ++++++++++++++++
 Next/docs/technologies.html                 |  19 ++++++
 Next/en/help.html                           |   7 ++
```
Hey @mmBabol, can you take a look at this?