### PR TITLE
adding dockerfile for buildroot. fixing #57

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 node_modules/*
 src/*
 tools/*
+dist/*
 
 .eslintignore
 .eslintrc.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules/*
+src/*
+tools/*
+
+.eslintignore
+.eslintrc.yml
+.gitignore
+.prettierrc.json
+.travis.yml
+LICENSE
+package*
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /var/run/sshd; \
     apt-get purge -q -y snapd lxcfs lxd ubuntu-core-launcher snap-confine;
 # install all deps.
 RUN apt-get -q -y install build-essential libncurses5-dev \
-    git bzr cvs libc6:i386 unzip bc wget openssh-server; \ 
+    git bzr cvs libc6:i386 unzip bc wget openssh-server cpio; \ 
     apt-get -q -y autoremove; \
     apt-get -q -y clean; \
     # Install Buildroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:xenial
+
+WORKDIR /root
+
+# Buildroot version to use
+ARG RELEASE=2018.02
+
+RUN mkdir /var/run/sshd
+RUN echo 'root:unbundeled' | chpasswd
+
+# Install all Buildroot deps
+RUN sed -i 's|deb http://us.archive.ubuntu.com/ubuntu/|deb mirror://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
+RUN apt-get update
+RUN dpkg --add-architecture i386
+RUN apt-get -q update
+RUN apt-get purge -q -y snapd lxcfs lxd ubuntu-core-launcher snap-confine
+RUN apt-get -q -y install build-essential libncurses5-dev \
+    git bzr cvs libc6:i386 unzip bc wget openssh-server
+RUN apt-get -q -y autoremove
+RUN apt-get -q -y clean
+
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+
+# configure the locales
+ENV LANG='C' LANGUAGE='en_US:en' LC_ALL='C'
+
+EXPOSE 22
+
+# Install Buildroot
+RUN wget -c http://buildroot.org/downloads/buildroot-${RELEASE}.tar.gz
+RUN tar axf buildroot-${RELEASE}.tar.gz
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ ENV LANG='C' LANGUAGE='en_US:en' LC_ALL='C'
 
 ENV NOTVISIBLE "in users profile"
 
+ENV TERM xtrem
+
 RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config; \
     # SSH login fix. Otherwise user is kicked off after login
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN echo 'root:unbundeled' | chpasswd; \
     apt-get purge -q -y snapd lxcfs lxd ubuntu-core-launcher snap-confine;
 # install all deps.
 RUN apt-get -q -y install build-essential libncurses5-dev \
-    git bzr cvs libc6:i386 unzip bc wget cpio; \ 
+    git bzr cvs libc6:i386 unzip bc wget cpio libssl-dev; \ 
     apt-get -q -y autoremove; \
     apt-get -q -y clean; \
     # Install Buildroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM rastasheep/ubuntu-sshd:16.04
 
 WORKDIR /root
 
@@ -6,8 +6,7 @@ WORKDIR /root
 ARG RELEASE=2018.02
 
 # configure root password
-RUN mkdir /var/run/sshd; \
-    echo 'root:unbundeled' | chpasswd; \
+RUN echo 'root:unbundeled' | chpasswd; \
     # Install all Buildroot deps
     sed -i 's|deb http://us.archive.ubuntu.com/ubuntu/|deb mirror://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list; \
     dpkg --add-architecture i386; \
@@ -15,7 +14,7 @@ RUN mkdir /var/run/sshd; \
     apt-get purge -q -y snapd lxcfs lxd ubuntu-core-launcher snap-confine;
 # install all deps.
 RUN apt-get -q -y install build-essential libncurses5-dev \
-    git bzr cvs libc6:i386 unzip bc wget openssh-server cpio; \ 
+    git bzr cvs libc6:i386 unzip bc wget cpio; \ 
     apt-get -q -y autoremove; \
     apt-get -q -y clean; \
     # Install Buildroot
@@ -23,17 +22,8 @@ RUN apt-get -q -y install build-essential libncurses5-dev \
     tar axf buildroot-${RELEASE}.tar.gz;
 
 # configure the locales
-ENV LANG='C' LANGUAGE='en_US:en' LC_ALL='C'
-
-ENV NOTVISIBLE "in users profile"
-
-ENV TERM xtrem
-
-RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config; \
-    # SSH login fix. Otherwise user is kicked off after login
-    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd; \
-    echo "export VISIBLE=now" >> /etc/profile;
-
-EXPOSE 22
-
-CMD ["/usr/sbin/sshd", "-D"]
+ENV LANG='C' \
+    LANGUAGE='en_US:en' \
+    LC_ALL='C' \ 
+    NOTVISIBLE="in users profile" \
+    TERM=xterm


### PR DESCRIPTION
Since not everyone has the same environment, we can run tasks like kernel compilation inside docker.
Things to note about this container:
* Based on Ubuntu 16.04 Xenial
* Env is configured based on [this](https://buildroot.org/downloads/Vagrantfile) Vagrant file
* You need to use an ssh connection to get inside the container. `docker exec -it [containerName] bash` does not work with the buildroot config menu because of the locales. Details found #57 
* SSH connection tested with Xterm terminal.
* Root password is `undundeled`
* You can specify which version of buildroot to use with [docker arguments](https://buildroot.org/downloads/Vagrantfile). Defaults to `2018.02`.

To get inside a container, you need to map internal container ports with `-p` or `-P` command when creating the container e.g. `docker run -P ...`

#57 