### PR TITLE
Fix #9, #59: Add filer to package.json, using my current dev branch on github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "abbrev": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+            "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+        },
         "accepts": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -18,7 +23,6 @@
             "version": "5.5.2",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-            "dev": true,
             "requires": {
                 "co": "4.6.0",
                 "fast-deep-equal": "1.1.0",
@@ -32,14 +36,11 @@
             "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
             "dev": true
         },
-        "ansi-gray": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-            "dev": true,
-            "requires": {
-                "ansi-wrap": "0.1.0"
-            }
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "optional": true
         },
         "ansi-red": {
             "version": "0.1.1",
@@ -59,7 +60,7 @@
         "ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
                 "color-convert": "1.9.1"
@@ -71,49 +72,23 @@
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
             "dev": true
         },
-        "archive-type": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
-            "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
-            "dev": true,
-            "requires": {
-                "file-type": "3.9.0"
-            },
-            "dependencies": {
-                "file-type": {
-                    "version": "3.9.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-                    "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-                    "dev": true
-                }
-            }
+        "archy": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz",
+            "integrity": "sha1-kQ9Dv2YUH8M1VkWXq8GJ30Sz014="
         },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
             "requires": {
                 "sprintf-js": "1.0.3"
             }
         },
-        "arr-flatten": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-            "dev": true
-        },
-        "array-differ": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-            "dev": true
-        },
-        "array-find-index": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-            "dev": true
+        "array-filter": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
         },
         "array-flatten": {
             "version": "1.1.1",
@@ -121,20 +96,15 @@
             "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
             "dev": true
         },
-        "array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true,
-            "requires": {
-                "array-uniq": "1.0.3"
-            }
+        "array-map": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
         },
-        "array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
+        "array-reduce": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
         },
         "asap": {
             "version": "2.0.6",
@@ -145,26 +115,22 @@
         "asn1": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-            "dev": true
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
         },
         "assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "dev": true
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
-        "async-each-series": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
-            "integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg=",
-            "dev": true
+        "async": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-            "dev": true
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "autolinker": {
             "version": "0.15.3",
@@ -179,90 +145,21 @@
             "dev": true,
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000839",
+                "caniuse-db": "1.0.30000841",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
                 "browserslist": {
                     "version": "1.7.7",
                     "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000839",
-                        "electron-to-chromium": "1.3.45"
-                    }
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
+                        "caniuse-db": "1.0.30000841",
+                        "electron-to-chromium": "1.3.46"
                     }
                 }
             }
@@ -270,14 +167,12 @@
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "dev": true
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-            "dev": true
+            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
         },
         "babel-code-frame": {
             "version": "6.26.0",
@@ -307,15 +202,6 @@
                         "has-ansi": "2.0.0",
                         "strip-ansi": "3.0.1",
                         "supports-color": "2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
                     }
                 },
                 "supports-color": {
@@ -351,20 +237,6 @@
                 "private": "0.1.8",
                 "slash": "1.0.0",
                 "source-map": "0.5.7"
-            },
-            "dependencies": {
-                "json5": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                }
             }
         },
         "babel-generator": {
@@ -383,10 +255,10 @@
                 "trim-right": "1.0.1"
             },
             "dependencies": {
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                "jsesc": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                    "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
                     "dev": true
                 }
             }
@@ -1102,159 +974,59 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base64-arraybuffer": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+            "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
         },
         "bcrypt-pbkdf": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-            "dev": true,
             "optional": true,
             "requires": {
                 "tweetnacl": "0.14.5"
             }
         },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-            "dev": true
-        },
-        "bin-build": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
-            "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
-            "dev": true,
+        "binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
             "requires": {
-                "archive-type": "3.2.0",
-                "decompress": "3.0.0",
-                "download": "4.4.3",
-                "exec-series": "1.0.3",
-                "rimraf": "2.6.2",
-                "tempfile": "1.1.1",
-                "url-regex": "3.2.0"
-            },
-            "dependencies": {
-                "tempfile": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
-                    "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-                    "dev": true,
-                    "requires": {
-                        "os-tmpdir": "1.0.2",
-                        "uuid": "2.0.3"
-                    }
-                },
-                "uuid": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-                    "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-                    "dev": true
-                }
-            }
-        },
-        "bin-check": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
-            "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
-            "dev": true,
-            "requires": {
-                "executable": "1.1.0"
-            }
-        },
-        "bin-version": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
-            "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
-            "dev": true,
-            "requires": {
-                "find-versions": "1.2.1"
-            }
-        },
-        "bin-version-check": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
-            "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
-            "dev": true,
-            "requires": {
-                "bin-version": "1.0.4",
-                "minimist": "1.2.0",
-                "semver": "4.3.6",
-                "semver-truncate": "1.1.2"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "4.3.6",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-                    "dev": true
-                }
-            }
-        },
-        "bin-wrapper": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
-            "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
-            "dev": true,
-            "requires": {
-                "bin-check": "2.0.0",
-                "bin-version-check": "2.1.0",
-                "download": "4.4.3",
-                "each-async": "1.1.1",
-                "lazy-req": "1.1.0",
-                "os-filter-obj": "1.0.3"
+                "buffers": "0.1.1",
+                "chainsaw": "0.1.0"
             }
         },
         "bl": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-            "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-            "dev": true,
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+            "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
             "requires": {
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2"
-            }
-        },
-        "body": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
-            "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
-            "dev": true,
-            "requires": {
-                "continuable-cache": "0.3.1",
-                "error": "7.0.2",
-                "raw-body": "1.1.7",
-                "safe-json-parse": "1.0.1"
+                "readable-stream": "1.0.34"
             },
             "dependencies": {
-                "bytes": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-                    "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
-                    "dev": true
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
-                "raw-body": {
-                    "version": "1.1.7",
-                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-                    "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-                    "dev": true,
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "bytes": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
                         "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 }
             }
         },
@@ -1284,17 +1056,583 @@
                 }
             }
         },
-        "boolbase": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-            "dev": true
+        "boom": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+            "requires": {
+                "hoek": "4.2.1"
+            }
+        },
+        "bower": {
+            "version": "1.3.12",
+            "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.12.tgz",
+            "integrity": "sha1-N94O2zkEuvkK7hM4Sho3mgXuIUw=",
+            "requires": {
+                "abbrev": "1.0.9",
+                "archy": "0.0.2",
+                "bower-config": "0.5.3",
+                "bower-endpoint-parser": "0.2.2",
+                "bower-json": "0.4.0",
+                "bower-logger": "0.2.2",
+                "bower-registry-client": "0.2.4",
+                "cardinal": "0.4.0",
+                "chalk": "0.5.0",
+                "chmodr": "0.1.0",
+                "decompress-zip": "0.0.8",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "glob": "4.0.6",
+                "graceful-fs": "3.0.11",
+                "handlebars": "2.0.0",
+                "inquirer": "0.7.1",
+                "insight": "0.4.3",
+                "is-root": "1.0.0",
+                "junk": "1.0.3",
+                "lockfile": "1.0.4",
+                "lru-cache": "2.5.2",
+                "mkdirp": "0.5.0",
+                "mout": "0.9.1",
+                "nopt": "3.0.6",
+                "opn": "1.0.2",
+                "osenv": "0.1.0",
+                "p-throttler": "0.1.0",
+                "promptly": "0.2.0",
+                "q": "1.0.1",
+                "request": "2.42.0",
+                "request-progress": "0.3.0",
+                "retry": "0.6.0",
+                "rimraf": "2.2.8",
+                "semver": "2.3.2",
+                "shell-quote": "1.4.3",
+                "stringify-object": "1.0.1",
+                "tar-fs": "0.5.2",
+                "tmp": "0.0.23",
+                "update-notifier": "0.2.0",
+                "which": "1.0.9"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+                },
+                "ansi-styles": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                    "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+                },
+                "asn1": {
+                    "version": "0.1.11",
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                    "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                    "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                    "optional": true
+                },
+                "async": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                    "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+                    "optional": true
+                },
+                "boom": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                    "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+                    "requires": {
+                        "hoek": "0.9.1"
+                    }
+                },
+                "caseless": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
+                    "integrity": "sha1-gWfBq4OX+1u5X5bSjlqBxQ8kesQ="
+                },
+                "chalk": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.0.tgz",
+                    "integrity": "sha1-N138y8IcCmCothvFt489wqVcIS8=",
+                    "requires": {
+                        "ansi-styles": "1.1.0",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "0.1.0",
+                        "strip-ansi": "0.3.0",
+                        "supports-color": "0.2.0"
+                    }
+                },
+                "combined-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                    "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+                    "optional": true,
+                    "requires": {
+                        "delayed-stream": "0.0.5"
+                    }
+                },
+                "cryptiles": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                    "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+                    "optional": true,
+                    "requires": {
+                        "boom": "0.4.2"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                    "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+                    "optional": true
+                },
+                "forever-agent": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                    "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+                },
+                "form-data": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                    "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+                    "optional": true,
+                    "requires": {
+                        "async": "0.9.2",
+                        "combined-stream": "0.0.7",
+                        "mime": "1.2.11"
+                    }
+                },
+                "glob": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+                    "integrity": "sha1-aVxQvdTi+1xdNwsJHziNNwfikac=",
+                    "requires": {
+                        "graceful-fs": "3.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "1.0.0",
+                        "once": "1.4.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "3.0.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+                    "requires": {
+                        "natives": "1.1.4"
+                    }
+                },
+                "has-ansi": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                    "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "hawk": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                    "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
+                    "optional": true,
+                    "requires": {
+                        "boom": "0.4.2",
+                        "cryptiles": "0.2.2",
+                        "hoek": "0.9.1",
+                        "sntp": "0.2.4"
+                    }
+                },
+                "hoek": {
+                    "version": "0.9.1",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                    "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+                },
+                "http-signature": {
+                    "version": "0.10.1",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                    "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.1.11",
+                        "assert-plus": "0.1.5",
+                        "ctype": "0.5.3"
+                    }
+                },
+                "lru-cache": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz",
+                    "integrity": "sha1-H92tk4quEmPOE4aAvhs/WRwKtBw="
+                },
+                "mime": {
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                    "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+                    "optional": true
+                },
+                "mime-types": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                    "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
+                },
+                "minimatch": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                    "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+                    "requires": {
+                        "lru-cache": "2.5.2",
+                        "sigmund": "1.0.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                    "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "node-uuid": {
+                    "version": "1.4.8",
+                    "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+                    "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+                },
+                "oauth-sign": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
+                    "integrity": "sha1-8ilW8x6nFRqCHl8vsywRPK2Ln2k=",
+                    "optional": true
+                },
+                "q": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
+                    "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ="
+                },
+                "qs": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+                    "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
+                },
+                "request": {
+                    "version": "2.42.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+                    "integrity": "sha1-VyvQFIk4VkBArHqxSLlkI6BjMEo=",
+                    "requires": {
+                        "aws-sign2": "0.5.0",
+                        "bl": "0.9.5",
+                        "caseless": "0.6.0",
+                        "forever-agent": "0.5.2",
+                        "form-data": "0.1.4",
+                        "hawk": "1.1.1",
+                        "http-signature": "0.10.1",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "1.0.2",
+                        "node-uuid": "1.4.8",
+                        "oauth-sign": "0.4.0",
+                        "qs": "1.2.2",
+                        "stringstream": "0.0.6",
+                        "tough-cookie": "2.3.4",
+                        "tunnel-agent": "0.4.3"
+                    }
+                },
+                "semver": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+                    "integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI="
+                },
+                "sntp": {
+                    "version": "0.2.4",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                    "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+                    "optional": true,
+                    "requires": {
+                        "hoek": "0.9.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                    "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                    "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+                },
+                "tunnel-agent": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+                },
+                "which": {
+                    "version": "1.0.9",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+                    "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
+                }
+            }
+        },
+        "bower-config": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.3.tgz",
+            "integrity": "sha1-mPxbQah4cO+cu5KXY1z4H1UF/bE=",
+            "requires": {
+                "graceful-fs": "2.0.3",
+                "mout": "0.9.1",
+                "optimist": "0.6.1",
+                "osenv": "0.0.3"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                    "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
+                },
+                "osenv": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+                    "integrity": "sha1-zWrY3bKQkVrZ4idlV2Al1BHynLY="
+                }
+            }
+        },
+        "bower-endpoint-parser": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
+            "integrity": "sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y="
+        },
+        "bower-json": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+            "integrity": "sha1-qZw8z0Fu8FkO0N7SUsdg8cbZN2Y=",
+            "requires": {
+                "deep-extend": "0.2.11",
+                "graceful-fs": "2.0.3",
+                "intersect": "0.0.3"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                    "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
+                }
+            }
+        },
+        "bower-logger": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
+            "integrity": "sha1-Ob4H6Xmy/I4DqUY0IF7ZQiNz04E="
+        },
+        "bower-registry-client": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
+            "integrity": "sha1-Jp/H6Ji2J/uTnRFEpZMlTX+77rw=",
+            "requires": {
+                "async": "0.2.10",
+                "bower-config": "0.5.3",
+                "graceful-fs": "2.0.3",
+                "lru-cache": "2.3.1",
+                "mkdirp": "0.3.5",
+                "request": "2.51.0",
+                "request-replay": "0.2.0",
+                "rimraf": "2.2.8"
+            },
+            "dependencies": {
+                "asn1": {
+                    "version": "0.1.11",
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                    "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+                },
+                "assert-plus": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                    "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+                },
+                "aws-sign2": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                    "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
+                },
+                "boom": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                    "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+                    "requires": {
+                        "hoek": "0.9.1"
+                    }
+                },
+                "caseless": {
+                    "version": "0.8.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                    "integrity": "sha1-W8oogdQUN/VLJAfr40iIx7mtT30="
+                },
+                "combined-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                    "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+                    "requires": {
+                        "delayed-stream": "0.0.5"
+                    }
+                },
+                "cryptiles": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                    "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+                    "requires": {
+                        "boom": "0.4.2"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                    "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+                },
+                "forever-agent": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                    "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+                },
+                "form-data": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                    "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+                    "requires": {
+                        "async": "0.9.2",
+                        "combined-stream": "0.0.7",
+                        "mime-types": "2.0.14"
+                    },
+                    "dependencies": {
+                        "async": {
+                            "version": "0.9.2",
+                            "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+                        },
+                        "mime-types": {
+                            "version": "2.0.14",
+                            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                            "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+                            "requires": {
+                                "mime-db": "1.12.0"
+                            }
+                        }
+                    }
+                },
+                "graceful-fs": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                    "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
+                },
+                "hawk": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                    "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
+                    "requires": {
+                        "boom": "0.4.2",
+                        "cryptiles": "0.2.2",
+                        "hoek": "0.9.1",
+                        "sntp": "0.2.4"
+                    }
+                },
+                "hoek": {
+                    "version": "0.9.1",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                    "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+                },
+                "http-signature": {
+                    "version": "0.10.1",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                    "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+                    "requires": {
+                        "asn1": "0.1.11",
+                        "assert-plus": "0.1.5",
+                        "ctype": "0.5.3"
+                    }
+                },
+                "lru-cache": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
+                    "integrity": "sha1-s632s9hW6VTiw5DmzvIggSRaU9Y="
+                },
+                "mime-db": {
+                    "version": "1.12.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                    "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+                },
+                "mime-types": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                    "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
+                },
+                "mkdirp": {
+                    "version": "0.3.5",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                    "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+                },
+                "node-uuid": {
+                    "version": "1.4.8",
+                    "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+                    "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+                },
+                "oauth-sign": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                    "integrity": "sha1-12f1FpMlYg6rLgh+8MRy53PbZGE="
+                },
+                "qs": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                    "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+                },
+                "request": {
+                    "version": "2.51.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                    "integrity": "sha1-NdALvswBLlX5B7G9ng29V3v+8m4=",
+                    "requires": {
+                        "aws-sign2": "0.5.0",
+                        "bl": "0.9.5",
+                        "caseless": "0.8.0",
+                        "combined-stream": "0.0.7",
+                        "forever-agent": "0.5.2",
+                        "form-data": "0.2.0",
+                        "hawk": "1.1.1",
+                        "http-signature": "0.10.1",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "1.0.2",
+                        "node-uuid": "1.4.8",
+                        "oauth-sign": "0.5.0",
+                        "qs": "2.3.3",
+                        "stringstream": "0.0.6",
+                        "tough-cookie": "2.3.4",
+                        "tunnel-agent": "0.4.3"
+                    }
+                },
+                "sntp": {
+                    "version": "0.2.4",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                    "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+                    "requires": {
+                        "hoek": "0.9.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+                }
+            }
         },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-            "dev": true,
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
                 "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
@@ -1306,37 +1644,9 @@
             "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "1.0.30000839",
-                "electron-to-chromium": "1.3.45"
+                "caniuse-lite": "1.0.30000841",
+                "electron-to-chromium": "1.3.46"
             }
-        },
-        "buffer-alloc": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
-            "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
-            "dev": true,
-            "requires": {
-                "buffer-alloc-unsafe": "0.1.1",
-                "buffer-fill": "0.1.1"
-            }
-        },
-        "buffer-alloc-unsafe": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
-            "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo=",
-            "dev": true
-        },
-        "buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-            "dev": true
-        },
-        "buffer-fill": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
-            "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q==",
-            "dev": true
         },
         "buffer-from": {
             "version": "1.0.0",
@@ -1344,61 +1654,16 @@
             "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
             "dev": true
         },
-        "buffer-to-vinyl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
-            "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
-            "dev": true,
-            "requires": {
-                "file-type": "3.9.0",
-                "readable-stream": "2.3.6",
-                "uuid": "2.0.3",
-                "vinyl": "1.2.0"
-            },
-            "dependencies": {
-                "file-type": {
-                    "version": "3.9.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-                    "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-                    "dev": true
-                },
-                "uuid": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-                    "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-                    "dev": true
-                }
-            }
-        },
-        "builtin-modules": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
+        "buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
         },
         "bytes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
             "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
             "dev": true
-        },
-        "camelcase-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-            "dev": true,
-            "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-                    "dev": true
-                }
-            }
         },
         "caniuse-api": {
             "version": "1.6.1",
@@ -1407,7 +1672,7 @@
             "dev": true,
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000839",
+                "caniuse-db": "1.0.30000841",
                 "lodash.memoize": "4.1.2",
                 "lodash.uniq": "4.5.0"
             },
@@ -1418,66 +1683,49 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000839",
-                        "electron-to-chromium": "1.3.45"
+                        "caniuse-db": "1.0.30000841",
+                        "electron-to-chromium": "1.3.46"
                     }
                 }
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000839",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000839.tgz",
-            "integrity": "sha1-VahuQCx0rhcUlwe+o+o5lSIjNJc=",
+            "version": "1.0.30000841",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000841.tgz",
+            "integrity": "sha1-26QAiVmQNI4t47cXlaUOg38Ts/Y=",
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30000839",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000839.tgz",
-            "integrity": "sha512-gJZIfmkuy84agOeAZc7WJOexZhisZaBSFk96gkGM6TkH7+1mBfr/MSPnXC8lO0g7guh/ucbswYjruvDbzc6i0g==",
+            "version": "1.0.30000841",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000841.tgz",
+            "integrity": "sha512-LeOGLEY4hl6xZc/xMYOrVmSrHOybyHWNShFN51qCmDXo69nEGKHTJTfe6jdWe4hLxSJcwEIYtKHFFh93fF/kNA==",
             "dev": true
         },
-        "capture-stack-trace": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-            "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-            "dev": true
+        "cardinal": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.0.tgz",
+            "integrity": "sha1-fRCq+yCDe94EPEXkOgyMKM2q5F4=",
+            "requires": {
+                "redeyed": "0.4.4"
+            }
         },
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-            "dev": true
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
-        "caw": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
-            "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
-            "dev": true,
+        "chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
             "requires": {
-                "get-proxy": "1.1.0",
-                "is-obj": "1.0.1",
-                "object-assign": "3.0.0",
-                "tunnel-agent": "0.4.3"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-                    "dev": true
-                },
-                "tunnel-agent": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                    "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-                    "dev": true
-                }
+                "traverse": "0.3.9"
             }
         },
         "chalk": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-            "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
+            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
                 "ansi-styles": "3.2.1",
@@ -1485,10 +1733,15 @@
                 "supports-color": "5.4.0"
             }
         },
+        "chmodr": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz",
+            "integrity": "sha1-4JIVodUVQtsqJXaWl2W89hJVg+s="
+        },
         "ci-info": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-            "integrity": "sha1-cQGTJkuwXHe4yQ0C9aryIhamZ7I=",
+            "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
             "dev": true
         },
         "clap": {
@@ -1519,15 +1772,6 @@
                         "supports-color": "2.0.0"
                     }
                 },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
                 "supports-color": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -1542,6 +1786,17 @@
             "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=",
             "dev": true
         },
+        "cli-color": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+            "integrity": "sha1-EtW90Vj/igsNtAEZiRPAPfBp9vU=",
+            "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.44",
+                "memoizee": "0.3.10",
+                "timers-ext": "0.1.5"
+            }
+        },
         "cli-cursor": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -1554,7 +1809,7 @@
         "cli-spinners": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-            "integrity": "sha1-ACwZkJEtDVlYDJO9NsBW3pnkJZo=",
+            "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
             "dev": true
         },
         "clone": {
@@ -1563,17 +1818,10 @@
             "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
             "dev": true
         },
-        "clone-stats": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-            "dev": true
-        },
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "coa": {
             "version": "1.0.4",
@@ -1591,20 +1839,19 @@
             "dev": true
         },
         "color": {
-            "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-            "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+            "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
                 "color-convert": "1.9.1",
-                "color-string": "0.3.0"
+                "color-string": "1.5.2"
             }
         },
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
                 "color-name": "1.1.3"
@@ -1617,19 +1864,14 @@
             "dev": true
         },
         "color-string": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-            "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+            "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "1.1.3",
+                "simple-swizzle": "0.2.2"
             }
-        },
-        "color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "dev": true
         },
         "colormin": {
             "version": "1.1.2",
@@ -1640,6 +1882,28 @@
                 "color": "0.11.4",
                 "css-color-names": "0.0.4",
                 "has": "1.0.1"
+            },
+            "dependencies": {
+                "color": {
+                    "version": "0.11.4",
+                    "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+                    "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.4",
+                        "color-convert": "1.9.1",
+                        "color-string": "0.3.0"
+                    }
+                },
+                "color-string": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+                    "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                }
             }
         },
         "colors": {
@@ -1652,7 +1916,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-            "dev": true,
             "requires": {
                 "delayed-stream": "1.0.0"
             }
@@ -1666,8 +1929,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
             "version": "1.6.2",
@@ -1681,11 +1943,49 @@
                 "typedarray": "0.0.6"
             }
         },
-        "console-stream": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
-            "integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ=",
-            "dev": true
+        "config-chain": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+            "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+            "requires": {
+                "ini": "1.3.5",
+                "proto-list": "1.2.4"
+            }
+        },
+        "configstore": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+            "integrity": "sha1-JeTBbDdoq/dcWmW8YXYfSVBVtFk=",
+            "requires": {
+                "graceful-fs": "3.0.11",
+                "js-yaml": "3.7.0",
+                "mkdirp": "0.5.1",
+                "object-assign": "2.1.1",
+                "osenv": "0.1.0",
+                "user-home": "1.1.1",
+                "uuid": "2.0.3",
+                "xdg-basedir": "1.0.1"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "3.0.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+                    "requires": {
+                        "natives": "1.1.4"
+                    }
+                },
+                "object-assign": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+                    "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+                },
+                "uuid": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+                    "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+                }
+            }
         },
         "content-disposition": {
             "version": "0.5.2",
@@ -1697,12 +1997,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-            "dev": true
-        },
-        "continuable-cache": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
-            "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
             "dev": true
         },
         "convert-source-map": {
@@ -1732,16 +2026,17 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
-        "create-error-class": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+        "create-react-class": {
+            "version": "15.6.3",
+            "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+            "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
             "dev": true,
             "requires": {
-                "capture-stack-trace": "1.0.0"
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
             }
         },
         "cross-spawn": {
@@ -1761,24 +2056,25 @@
             "integrity": "sha1-6smYmm/n/qrzMJA5evwYfGe0YZE=",
             "dev": true,
             "requires": {
-                "request": "2.87.0",
+                "request": "2.86.0",
                 "yamljs": "0.2.10",
                 "yargs": "2.3.0"
+            }
+        },
+        "cryptiles": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+            "requires": {
+                "boom": "5.2.0"
             },
             "dependencies": {
-                "wordwrap": {
-                    "version": "0.0.2",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-2.3.0.tgz",
-                    "integrity": "sha1-6QDIclDsXNCA22AJ/j3WMVbx1/s=",
-                    "dev": true,
+                "boom": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                     "requires": {
-                        "wordwrap": "0.0.2"
+                        "hoek": "4.2.1"
                     }
                 }
             }
@@ -1787,66 +2083,6 @@
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
             "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
-            "dev": true
-        },
-        "css-select": {
-            "version": "1.3.0-rc0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.3.0-rc0.tgz",
-            "integrity": "sha1-b5MZaqrnN2ZuoQNqjLFKj8t6kjE=",
-            "dev": true,
-            "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
-                "domutils": "1.5.1",
-                "nth-check": "1.0.1"
-            },
-            "dependencies": {
-                "domutils": {
-                    "version": "1.5.1",
-                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                    "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-                    "dev": true,
-                    "requires": {
-                        "dom-serializer": "0.1.0",
-                        "domelementtype": "1.3.0"
-                    }
-                }
-            }
-        },
-        "css-select-base-adapter": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.0.tgz",
-            "integrity": "sha1-AQKz0UYw34bD65+p9UVicBBs+ZA=",
-            "dev": true
-        },
-        "css-tree": {
-            "version": "1.0.0-alpha25",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha25.tgz",
-            "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
-            "dev": true,
-            "requires": {
-                "mdn-data": "1.1.2",
-                "source-map": "0.5.7"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                }
-            }
-        },
-        "css-url-regex": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
-            "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
-            "dev": true
-        },
-        "css-what": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-            "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
             "dev": true
         },
         "cssnano": {
@@ -1887,77 +2123,6 @@
                 "postcss-unique-selectors": "2.0.2",
                 "postcss-value-parser": "3.3.0",
                 "postcss-zindex": "2.2.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "csso": {
@@ -1968,39 +2133,28 @@
             "requires": {
                 "clap": "1.2.3",
                 "source-map": "0.5.7"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                }
             }
         },
-        "currently-unhandled": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-            "dev": true,
+        "ctype": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+            "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+        },
+        "d": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+            "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
             "requires": {
-                "array-find-index": "1.0.2"
+                "es5-ext": "0.10.44"
             }
         },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0"
             }
-        },
-        "dateformat": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-            "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-            "dev": true
         },
         "debug": {
             "version": "2.6.9",
@@ -2017,60 +2171,50 @@
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
-        "decompress": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
-            "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
-            "dev": true,
+        "decompress-zip": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
+            "integrity": "sha1-SiZbIseyCdeyT6ZvKy37ztWQRPM=",
             "requires": {
-                "buffer-to-vinyl": "1.1.0",
-                "concat-stream": "1.6.2",
-                "decompress-tar": "3.1.0",
-                "decompress-tarbz2": "3.1.0",
-                "decompress-targz": "3.1.0",
-                "decompress-unzip": "3.4.0",
-                "stream-combiner2": "1.1.1",
-                "vinyl-assign": "1.2.1",
-                "vinyl-fs": "2.4.4"
-            }
-        },
-        "decompress-tar": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
-            "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
-            "dev": true,
-            "requires": {
-                "is-tar": "1.0.0",
-                "object-assign": "2.1.1",
-                "strip-dirs": "1.1.1",
-                "tar-stream": "1.6.1",
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "binary": "0.3.0",
+                "graceful-fs": "3.0.11",
+                "mkpath": "0.1.0",
+                "nopt": "2.2.1",
+                "q": "1.0.1",
+                "readable-stream": "1.1.14",
+                "touch": "0.0.2"
             },
             "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
+                "graceful-fs": {
+                    "version": "3.0.11",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+                    "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+                    "requires": {
+                        "natives": "1.1.4"
+                    }
                 },
                 "isarray": {
                     "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
-                "object-assign": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-                    "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-                    "dev": true
+                "nopt": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                    "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+                    "requires": {
+                        "abbrev": "1.0.9"
+                    }
+                },
+                "q": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
+                    "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ="
                 },
                 "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
                         "core-util-is": "1.0.2",
                         "inherits": "2.0.3",
@@ -2081,206 +2225,20 @@
                 "string_decoder": {
                     "version": "0.10.31",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
-                    }
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 }
-            }
-        },
-        "decompress-tarbz2": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
-            "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
-            "dev": true,
-            "requires": {
-                "is-bzip2": "1.0.0",
-                "object-assign": "2.1.1",
-                "seek-bzip": "1.0.5",
-                "strip-dirs": "1.1.1",
-                "tar-stream": "1.6.1",
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "object-assign": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-                    "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
-                    }
-                }
-            }
-        },
-        "decompress-targz": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
-            "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
-            "dev": true,
-            "requires": {
-                "is-gzip": "1.0.0",
-                "object-assign": "2.1.1",
-                "strip-dirs": "1.1.1",
-                "tar-stream": "1.6.1",
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                    "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "object-assign": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-                    "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                },
-                "vinyl": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-                    "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
-                    }
-                }
-            }
-        },
-        "decompress-unzip": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
-            "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
-            "dev": true,
-            "requires": {
-                "is-zip": "1.0.0",
-                "read-all-stream": "3.1.0",
-                "stat-mode": "0.2.2",
-                "strip-dirs": "1.1.1",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0",
-                "yauzl": "2.9.1"
             }
         },
         "deep-extend": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-            "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
-            "dev": true
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+            "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
         },
-        "define-properties": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-            "dev": true,
-            "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
-            }
+        "deep-is": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz",
+            "integrity": "sha1-nO1l6gvAsJ9CptecGxkD+dkTzBg=",
+            "dev": true
         },
         "defined": {
             "version": "1.0.0",
@@ -2291,8 +2249,7 @@
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "depd": {
             "version": "1.1.2",
@@ -2324,13 +2281,13 @@
         "diff-match-patch": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.1.tgz",
-            "integrity": "sha1-1fiAIT2C+8Ek0rlREfs8Az261/o=",
+            "integrity": "sha512-A0QEhr4PxGUMEtKxd6X+JLnOTFd3BfIPSDpsc4dMvj+CbSaErDwTpoTo/nFJDMSrjxLW4BiNq+FbNisAAHhWeQ==",
             "dev": true
         },
         "docusaurus": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/docusaurus/-/docusaurus-1.1.3.tgz",
-            "integrity": "sha512-1NM8wcyfHyWJpdAn9Ted/XjzuwSmAJqSxEKofuPzc6mzh8RQVA/nwDGds3dl2mrMUWIgQa8ICAXWBScQHSSm1w==",
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/docusaurus/-/docusaurus-1.0.15.tgz",
+            "integrity": "sha512-2y3s8P3VxKY+lB7ukQ8HaC0hKRuC8X3TExrGjnCgZYHd1aXYOwxfJnrphw3HA8Jai3EsDdoLV4mKaq/YsbYXSw==",
             "dev": true,
             "requires": {
                 "babel-plugin-transform-class-properties": "6.24.1",
@@ -2351,152 +2308,24 @@
                 "express": "4.16.3",
                 "feed": "1.1.1",
                 "fs-extra": "5.0.0",
-                "gaze": "1.1.3",
                 "glob": "7.1.2",
                 "highlight.js": "9.12.0",
-                "imagemin": "5.3.1",
-                "imagemin-gifsicle": "5.2.0",
-                "imagemin-jpegtran": "5.0.2",
-                "imagemin-optipng": "5.2.1",
-                "imagemin-svgo": "6.0.0",
                 "markdown-toc": "1.2.0",
                 "mkdirp": "0.5.1",
-                "opn": "5.3.0",
-                "react": "16.4.0",
-                "react-dom": "16.4.0",
+                "react": "15.6.2",
+                "react-dom": "15.6.2",
+                "react-dom-factories": "1.0.2",
                 "remarkable": "1.7.1",
-                "request": "2.87.0",
+                "request": "2.86.0",
                 "shelljs": "0.7.8",
                 "sitemap": "1.13.0",
-                "tcp-port-used": "0.1.2",
-                "tiny-lr": "1.1.1",
-                "tree-node-cli": "1.2.1"
-            },
-            "dependencies": {
-                "color": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
-                    "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "1.9.1",
-                        "color-string": "1.5.2"
-                    }
-                },
-                "color-string": {
-                    "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
-                    "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3",
-                        "simple-swizzle": "0.2.2"
-                    }
-                },
-                "fs-extra": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-                    "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.1"
-                    }
-                }
-            }
-        },
-        "dom-serializer": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-            "dev": true,
-            "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
-            },
-            "dependencies": {
-                "domelementtype": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-                    "dev": true
-                }
-            }
-        },
-        "domelementtype": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-            "dev": true
-        },
-        "download": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
-            "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
-            "dev": true,
-            "requires": {
-                "caw": "1.2.0",
-                "concat-stream": "1.6.2",
-                "each-async": "1.1.1",
-                "filenamify": "1.2.1",
-                "got": "5.7.1",
-                "gulp-decompress": "1.2.0",
-                "gulp-rename": "1.2.3",
-                "is-url": "1.2.4",
-                "object-assign": "4.1.1",
-                "read-all-stream": "3.1.0",
-                "readable-stream": "2.3.6",
-                "stream-combiner2": "1.1.1",
-                "vinyl": "1.2.0",
-                "vinyl-fs": "2.4.4",
-                "ware": "1.3.0"
-            }
-        },
-        "duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.3.6"
-            }
-        },
-        "duplexify": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-            "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
-            }
-        },
-        "each-async": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
-            "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
-            "dev": true,
-            "requires": {
-                "onetime": "1.1.0",
-                "set-immediate-shim": "1.0.1"
-            },
-            "dependencies": {
-                "onetime": {
-                    "version": "1.1.0",
-                    "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-                    "dev": true
-                }
+                "tcp-port-used": "0.1.2"
             }
         },
         "ecc-jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-            "dev": true,
             "optional": true,
             "requires": {
                 "jsbn": "0.1.1"
@@ -2509,9 +2338,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.45",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
-            "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g=",
+            "version": "1.3.46",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.46.tgz",
+            "integrity": "sha1-AOheIidUFaiHUF5KtJc3GU8YubA=",
             "dev": true
         },
         "encodeurl": {
@@ -2530,69 +2359,102 @@
             }
         },
         "end-of-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-            "dev": true,
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+            "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
             "requires": {
-                "once": "1.4.0"
-            }
-        },
-        "entities": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-            "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-            "dev": true
-        },
-        "error": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-            "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-            "dev": true,
-            "requires": {
-                "string-template": "0.2.1",
-                "xtend": "4.0.1"
-            }
-        },
-        "error-ex": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-            "dev": true,
-            "requires": {
-                "is-arrayish": "0.2.1"
+                "once": "1.3.3"
             },
             "dependencies": {
-                "is-arrayish": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-                    "dev": true
+                "once": {
+                    "version": "1.3.3",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                    "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
                 }
             }
         },
-        "es-abstract": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
-            "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
-            "dev": true,
+        "es5-ext": {
+            "version": "0.10.44",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.44.tgz",
+            "integrity": "sha512-TO4Vt9IhW3FzDKLDOpoA8VS9BCV4b9WTf6BqvMOgfoa8wX73F3Kh3y2J7yTstTaXlQ0k1vq4DH2vw6RSs42z+g==",
             "requires": {
-                "es-to-primitive": "1.1.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.1",
-                "is-callable": "1.1.3",
-                "is-regex": "1.0.4"
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "next-tick": "1.0.0"
             }
         },
-        "es-to-primitive": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-            "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-            "dev": true,
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "requires": {
-                "is-callable": "1.1.3",
-                "is-date-object": "1.0.1",
-                "is-symbol": "1.0.1"
+                "d": "1.0.0",
+                "es5-ext": "0.10.44",
+                "es6-symbol": "3.1.1"
+            },
+            "dependencies": {
+                "d": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                    "requires": {
+                        "es5-ext": "0.10.44"
+                    }
+                }
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.44"
+            },
+            "dependencies": {
+                "d": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                    "requires": {
+                        "es5-ext": "0.10.44"
+                    }
+                }
+            }
+        },
+        "es6-weak-map": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+            "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+            "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.44",
+                "es6-iterator": "0.1.3",
+                "es6-symbol": "2.0.1"
+            },
+            "dependencies": {
+                "es6-iterator": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                    "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+                    "requires": {
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.44",
+                        "es6-symbol": "2.0.1"
+                    }
+                },
+                "es6-symbol": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                    "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
+                    "requires": {
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.44"
+                    }
+                }
             }
         },
         "escape-html": {
@@ -2604,14 +2466,12 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "esprima": {
             "version": "2.7.3",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-            "dev": true
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
         },
         "esutils": {
             "version": "2.0.2",
@@ -2625,56 +2485,29 @@
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
             "dev": true
         },
-        "exec-buffer": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
-            "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
-            "dev": true,
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "requires": {
-                "execa": "0.7.0",
-                "p-finally": "1.0.0",
-                "pify": "3.0.0",
-                "rimraf": "2.6.2",
-                "tempfile": "2.0.0"
+                "d": "1.0.0",
+                "es5-ext": "0.10.44"
             },
             "dependencies": {
-                "execa": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-                    "dev": true,
+                "d": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "es5-ext": "0.10.44"
                     }
-                },
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
                 }
-            }
-        },
-        "exec-series": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
-            "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
-            "dev": true,
-            "requires": {
-                "async-each-series": "1.1.0",
-                "object-assign": "4.1.1"
             }
         },
         "execa": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-            "integrity": "sha1-rbfOYs+YUHH2BYDetKiLnjRxLQE=",
+            "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
             "dev": true,
             "requires": {
                 "cross-spawn": "5.1.0",
@@ -2686,15 +2519,6 @@
                 "strip-eof": "1.0.0"
             }
         },
-        "executable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
-            "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
-            "dev": true,
-            "requires": {
-                "meow": "3.7.0"
-            }
-        },
         "expand-range": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
@@ -2702,48 +2526,6 @@
             "dev": true,
             "requires": {
                 "fill-range": "2.2.4"
-            },
-            "dependencies": {
-                "fill-range": {
-                    "version": "2.2.4",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-                    "dev": true,
-                    "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "3.0.0",
-                        "repeat-element": "1.1.2",
-                        "repeat-string": "1.6.1"
-                    }
-                },
-                "is-number": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    }
-                },
-                "isobject": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                    "dev": true,
-                    "requires": {
-                        "isarray": "1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
             }
         },
         "express": {
@@ -2801,46 +2583,31 @@
         "extend": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-            "dev": true
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
+        "extend-shallow": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+            "dev": true,
+            "requires": {
+                "is-extendable": "0.1.1"
+            }
         },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "dev": true
-        },
-        "fancy-log": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
-            "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-            "dev": true,
-            "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
-            }
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-            "dev": true
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-            "dev": true
-        },
-        "faye-websocket": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-            "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-            "dev": true,
-            "requires": {
-                "websocket-driver": "0.7.0"
-            }
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "fbjs": {
             "version": "0.8.16",
@@ -2865,15 +2632,6 @@
                 }
             }
         },
-        "fd-slicer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-            "dev": true,
-            "requires": {
-                "pend": "1.2.0"
-            }
-        },
         "feed": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/feed/-/feed-1.1.1.tgz",
@@ -2887,39 +2645,46 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-            "dev": true,
             "requires": {
                 "escape-string-regexp": "1.0.5",
                 "object-assign": "4.1.1"
             }
         },
-        "file-type": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
-            "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU=",
-            "dev": true
+        "filer": {
+            "version": "github:humphd/filer#a3bfd5dd08d5f245e90d97dafb3428769b437e62",
+            "requires": {
+                "base64-arraybuffer": "0.1.5",
+                "bower": "1.3.12",
+                "minimatch": "1.0.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "2.7.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                    "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+                },
+                "minimatch": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                    "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+                    "requires": {
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
+                    }
+                }
+            }
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
-        },
-        "filename-reserved-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-            "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
-            "dev": true
-        },
-        "filenamify": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
-            "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+        "fill-range": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+            "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "filename-reserved-regex": "1.0.0",
-                "strip-outer": "1.0.1",
-                "trim-repeated": "1.0.0"
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "3.0.0",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
             }
         },
         "finalhandler": {
@@ -2946,24 +2711,6 @@
                 "locate-path": "2.0.0"
             }
         },
-        "find-versions": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
-            "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
-            "dev": true,
-            "requires": {
-                "array-uniq": "1.0.3",
-                "get-stdin": "4.0.1",
-                "meow": "3.7.0",
-                "semver-regex": "1.0.0"
-            }
-        },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
-        },
         "flatten": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -2976,32 +2723,15 @@
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
         },
-        "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true,
-            "requires": {
-                "for-in": "1.0.2"
-            }
-        },
-        "foreach": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-            "dev": true
-        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "dev": true
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-            "dev": true,
             "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.6",
@@ -3020,11 +2750,16 @@
             "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
             "dev": true
         },
-        "fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
+        "fs-extra": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+            "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "jsonfile": "4.0.0",
+                "universalify": "0.1.1"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -3032,34 +2767,31 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fstream": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.2.8"
+            }
+        },
+        "fstream-ignore": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+            "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+            "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+            }
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
-        },
-        "gaze": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-            "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-            "dev": true,
-            "requires": {
-                "globule": "1.2.0"
-            }
-        },
-        "get-proxy": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
-            "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
-            "dev": true,
-            "requires": {
-                "rc": "1.2.7"
-            }
-        },
-        "get-stdin": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
             "dev": true
         },
         "get-stream": {
@@ -3072,26 +2804,14 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0"
-            }
-        },
-        "gifsicle": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/gifsicle/-/gifsicle-3.0.4.tgz",
-            "integrity": "sha1-9Fy17RAWW2ZdySng6TKLbIId+js=",
-            "dev": true,
-            "requires": {
-                "bin-build": "2.2.0",
-                "bin-wrapper": "3.0.2",
-                "logalot": "2.1.0"
             }
         },
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
                 "fs.realpath": "1.0.0",
@@ -3102,299 +2822,31 @@
                 "path-is-absolute": "1.0.1"
             }
         },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "2.0.1"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
-            }
-        },
-        "glob-parent": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "dev": true,
-            "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
-            },
-            "dependencies": {
-                "is-glob": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "2.1.1"
-                    }
-                }
-            }
-        },
-        "glob-stream": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-            "dev": true,
-            "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "1.1.0"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "0.1.1"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
-                    }
-                },
-                "normalize-path": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-                    "dev": true,
-                    "requires": {
-                        "remove-trailing-separator": "1.1.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                }
-            }
-        },
         "globals": {
             "version": "9.18.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
             "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
             "dev": true
         },
-        "globby": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-            "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-            "dev": true,
-            "requires": {
-                "array-union": "1.0.2",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-            }
-        },
-        "globule": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-            "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
-            "dev": true,
-            "requires": {
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4"
-            }
-        },
-        "glogg": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-            "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
-            "dev": true,
-            "requires": {
-                "sparkles": "1.0.1"
-            }
-        },
         "got": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-            "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-            "dev": true,
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-0.3.0.tgz",
+            "integrity": "sha1-iI7GbKS8c1qwidvpWUltD3lIVJM=",
             "requires": {
-                "create-error-class": "3.0.2",
-                "duplexer2": "0.1.4",
-                "is-redirect": "1.0.0",
-                "is-retry-allowed": "1.1.0",
-                "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.1",
-                "node-status-codes": "1.0.0",
-                "object-assign": "4.1.1",
-                "parse-json": "2.2.0",
-                "pinkie-promise": "2.0.1",
-                "read-all-stream": "3.1.0",
-                "readable-stream": "2.3.6",
-                "timed-out": "3.1.3",
-                "unzip-response": "1.0.2",
-                "url-parse-lax": "1.0.0"
+                "object-assign": "0.3.1"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz",
+                    "integrity": "sha1-Bg4qKifXwNd+x3t48Rqkf9iACNI="
+                }
             }
         },
         "graceful-fs": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-            "dev": true
-        },
-        "graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-            "dev": true
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "gray-matter": {
             "version": "2.1.1",
@@ -3409,186 +2861,52 @@
                 "toml": "2.3.3"
             },
             "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                "esprima": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+                    "dev": true
+                },
+                "js-yaml": {
+                    "version": "3.11.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+                    "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "argparse": "1.0.10",
+                        "esprima": "4.0.0"
                     }
                 }
             }
         },
-        "gulp-decompress": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
-            "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
-            "dev": true,
+        "handlebars": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+            "integrity": "sha1-bp1/hRSjRn+l6fgswVjs/B1ax28=",
             "requires": {
-                "archive-type": "3.2.0",
-                "decompress": "3.0.0",
-                "gulp-util": "3.0.8",
-                "readable-stream": "2.3.6"
-            }
-        },
-        "gulp-rename": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.3.tgz",
-            "integrity": "sha512-CmdPM0BjJ105QCX1fk+j7NGhiN/1rCl9HLGss+KllBS/tdYadpjTxqdKyh/5fNV+M3yjT1MFz5z93bXdrTyzAw==",
-            "dev": true
-        },
-        "gulp-sourcemaps": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-            "dev": true,
-            "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
-            }
-        },
-        "gulp-util": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-            "dev": true,
-            "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
-                "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "optimist": "0.3.7",
+                "uglify-js": "2.3.6"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
+                "optimist": {
+                    "version": "0.3.7",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                    "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "lodash.template": {
-                    "version": "3.6.2",
-                    "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-                    "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._basecopy": "3.0.1",
-                        "lodash._basetostring": "3.0.1",
-                        "lodash._basevalues": "3.0.0",
-                        "lodash._isiterateecall": "3.0.9",
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.escape": "3.2.0",
-                        "lodash.keys": "3.1.2",
-                        "lodash.restparam": "3.6.1",
-                        "lodash.templatesettings": "3.1.1"
-                    }
-                },
-                "lodash.templatesettings": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-                    "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-                    "dev": true,
-                    "requires": {
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.escape": "3.2.0"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "object-assign": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "0.5.3",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-                    "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
+                        "wordwrap": "0.0.2"
                     }
                 }
-            }
-        },
-        "gulplog": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true,
-            "requires": {
-                "glogg": "1.0.1"
             }
         },
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "dev": true
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-            "dev": true,
             "requires": {
                 "ajv": "5.5.2",
                 "har-schema": "2.0.0"
@@ -3618,13 +2936,15 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
-        "has-gulplog": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "dev": true,
+        "hawk": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
             "requires": {
-                "sparkles": "1.0.1"
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
             }
         },
         "highlight.js": {
@@ -3632,6 +2952,11 @@
             "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
             "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
             "dev": true
+        },
+        "hoek": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
         "home-or-tmp": {
             "version": "2.0.0",
@@ -3642,12 +2967,6 @@
                 "os-homedir": "1.0.2",
                 "os-tmpdir": "1.0.2"
             }
-        },
-        "hosted-git-info": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-            "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
-            "dev": true
         },
         "html-comment-regex": {
             "version": "1.1.1",
@@ -3667,17 +2986,10 @@
                 "statuses": "1.4.0"
             }
         },
-        "http-parser-js": {
-            "version": "0.4.13",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
-            "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
-            "dev": true
-        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
@@ -3687,7 +2999,7 @@
         "husky": {
             "version": "0.14.3",
             "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-            "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
+            "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
             "dev": true,
             "requires": {
                 "is-ci": "1.1.0",
@@ -3704,157 +3016,8 @@
         "ignore": {
             "version": "3.3.8",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-            "integrity": "sha1-P46cNdOHCKOn4Omrtsc+fudweys=",
+            "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
             "dev": true
-        },
-        "imagemin": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
-            "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
-            "dev": true,
-            "requires": {
-                "file-type": "4.4.0",
-                "globby": "6.1.0",
-                "make-dir": "1.3.0",
-                "p-pipe": "1.2.0",
-                "pify": "2.3.0",
-                "replace-ext": "1.0.0"
-            }
-        },
-        "imagemin-gifsicle": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-5.2.0.tgz",
-            "integrity": "sha512-K01m5QuPK+0en8oVhiOOAicF7KjrHlCZxS++mfLI2mV/Ksfq/Y9nCXCWDz6jRv13wwlqe5T7hXT+ji2DnLc2yQ==",
-            "dev": true,
-            "requires": {
-                "exec-buffer": "3.2.0",
-                "gifsicle": "3.0.4",
-                "is-gif": "1.0.0"
-            }
-        },
-        "imagemin-jpegtran": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/imagemin-jpegtran/-/imagemin-jpegtran-5.0.2.tgz",
-            "integrity": "sha1-5ogiY7j3kW/duABkDPddLpcNKtY=",
-            "dev": true,
-            "requires": {
-                "exec-buffer": "3.2.0",
-                "is-jpg": "1.0.1",
-                "jpegtran-bin": "3.2.0"
-            }
-        },
-        "imagemin-optipng": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-5.2.1.tgz",
-            "integrity": "sha1-0i2kEsCfX/AKQzmWC5ioix2+hpU=",
-            "dev": true,
-            "requires": {
-                "exec-buffer": "3.2.0",
-                "is-png": "1.1.0",
-                "optipng-bin": "3.1.4"
-            }
-        },
-        "imagemin-svgo": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-6.0.0.tgz",
-            "integrity": "sha512-xwjBZQKpbkklHtJYnCOwRJjTRJA/nR0hQzKMh+CUZRvm/L0QwKKPJQ9tkPWQHrg+cydPu2i1vLgHuy2E0hKEkg==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "0.1.2",
-                "is-svg": "2.1.0",
-                "svgo": "1.0.5"
-            },
-            "dependencies": {
-                "buffer-from": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-                    "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
-                    "dev": true
-                },
-                "coa": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.1.tgz",
-                    "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
-                    "dev": true,
-                    "requires": {
-                        "q": "1.5.1"
-                    }
-                },
-                "csso": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.0.tgz",
-                    "integrity": "sha512-WtJjFP3ZsSdWhiZr4/k1B9uHPgYjFYnDxfbaJxk1hz5PDLIJ5BCRWkJqaztZ0DbP8d2ZIVwUPIJb2YmCwkPaMw==",
-                    "dev": true,
-                    "requires": {
-                        "css-tree": "1.0.0-alpha.27"
-                    },
-                    "dependencies": {
-                        "css-tree": {
-                            "version": "1.0.0-alpha.27",
-                            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.27.tgz",
-                            "integrity": "sha512-BAYp9FyN4jLXjfvRpTDchBllDptqlK9I7OsagXCG9Am5C+5jc8eRZHgqb9x500W2OKS14MMlpQc/nmh/aA7TEQ==",
-                            "dev": true,
-                            "requires": {
-                                "mdn-data": "1.1.2",
-                                "source-map": "0.5.7"
-                            }
-                        }
-                    }
-                },
-                "esprima": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-                    "dev": true
-                },
-                "js-yaml": {
-                    "version": "3.10.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-                    "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "4.0.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "svgo": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.0.5.tgz",
-                    "integrity": "sha512-nYrifviB77aNKDNKKyuay3M9aYiK6Hv5gJVDdjj2ZXTQmI8WZc8+UPLR5IpVlktJfSu3co/4XcWgrgI6seGBPg==",
-                    "dev": true,
-                    "requires": {
-                        "coa": "2.0.1",
-                        "colors": "1.1.2",
-                        "css-select": "1.3.0-rc0",
-                        "css-select-base-adapter": "0.1.0",
-                        "css-tree": "1.0.0-alpha25",
-                        "css-url-regex": "1.1.0",
-                        "csso": "3.5.0",
-                        "js-yaml": "3.10.0",
-                        "mkdirp": "0.5.1",
-                        "object.values": "1.0.4",
-                        "sax": "1.2.4",
-                        "stable": "0.1.8",
-                        "unquote": "1.1.1",
-                        "util.promisify": "1.0.0"
-                    }
-                }
-            }
-        },
-        "indent-string": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-            "dev": true,
-            "requires": {
-                "repeating": "2.0.1"
-            }
         },
         "indexes-of": {
             "version": "1.0.1",
@@ -3875,20 +3038,186 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-            "dev": true
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+        },
+        "inquirer": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.7.1.tgz",
+            "integrity": "sha1-uKzxQBZb1YGGLtEZj7bSZDAJH6w=",
+            "requires": {
+                "chalk": "0.5.1",
+                "cli-color": "0.3.3",
+                "figures": "1.7.0",
+                "lodash": "2.4.2",
+                "mute-stream": "0.0.4",
+                "readline2": "0.1.1",
+                "rx": "2.5.3",
+                "through": "2.3.8"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+                },
+                "ansi-styles": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                    "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+                },
+                "chalk": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                    "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+                    "requires": {
+                        "ansi-styles": "1.1.0",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "0.1.0",
+                        "strip-ansi": "0.3.0",
+                        "supports-color": "0.2.0"
+                    }
+                },
+                "has-ansi": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                    "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "lodash": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                    "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+                },
+                "strip-ansi": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                    "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                    "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+                }
+            }
+        },
+        "insight": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
+            "integrity": "sha1-dtZTxcDYBIsDzbpjhaaUj3RhSvA=",
+            "requires": {
+                "async": "0.9.2",
+                "chalk": "0.5.1",
+                "configstore": "0.3.2",
+                "inquirer": "0.6.0",
+                "lodash.debounce": "2.4.1",
+                "object-assign": "1.0.0",
+                "os-name": "1.0.3",
+                "request": "2.86.0",
+                "tough-cookie": "0.12.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+                },
+                "ansi-styles": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                    "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+                },
+                "async": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+                },
+                "chalk": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                    "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+                    "requires": {
+                        "ansi-styles": "1.1.0",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "0.1.0",
+                        "strip-ansi": "0.3.0",
+                        "supports-color": "0.2.0"
+                    }
+                },
+                "has-ansi": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                    "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "inquirer": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
+                    "integrity": "sha1-YU17s+SPnmqAKOlKDDjyPvKYI9M=",
+                    "requires": {
+                        "chalk": "0.5.1",
+                        "cli-color": "0.3.3",
+                        "lodash": "2.4.2",
+                        "mute-stream": "0.0.4",
+                        "readline2": "0.1.1",
+                        "rx": "2.5.3",
+                        "through": "2.3.8"
+                    }
+                },
+                "lodash": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                    "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+                },
+                "object-assign": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                    "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY="
+                },
+                "strip-ansi": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                    "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                    "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+                },
+                "tough-cookie": {
+                    "version": "0.12.1",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                    "integrity": "sha1-giDH4hq9WxPZaAQlS9WoHr8sfWI=",
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                }
+            }
         },
         "interpret": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
             "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
             "dev": true
+        },
+        "intersect": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
+            "integrity": "sha1-waSl5erG7eSvdQTMB+Ctp7yfSSA="
         },
         "invariant": {
             "version": "2.2.4",
@@ -3899,26 +3228,11 @@
                 "loose-envify": "1.3.1"
             }
         },
-        "ip-regex": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-            "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
-            "dev": true
-        },
         "ipaddr.js": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
             "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
             "dev": true
-        },
-        "is-absolute": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-            "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
-            "dev": true,
-            "requires": {
-                "is-relative": "0.1.3"
-            }
         },
         "is-absolute-url": {
             "version": "2.1.0",
@@ -3938,67 +3252,19 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
-        "is-builtin-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-            "dev": true,
-            "requires": {
-                "builtin-modules": "1.1.1"
-            }
-        },
-        "is-bzip2": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
-            "integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w=",
-            "dev": true
-        },
-        "is-callable": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-            "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-            "dev": true
-        },
         "is-ci": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-            "integrity": "sha1-JH5BYueGDOu9rzC3dNawrH3P56U=",
+            "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
             "dev": true,
             "requires": {
                 "ci-info": "1.1.3"
-            }
-        },
-        "is-date-object": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-            "dev": true
-        },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
-        },
-        "is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
         },
         "is-finite": {
@@ -4010,35 +3276,14 @@
                 "number-is-nan": "1.0.1"
             }
         },
-        "is-gif": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-gif/-/is-gif-1.0.0.tgz",
-            "integrity": "sha1-ptKumIkwB7/6l6HYwB1jIFgyCX4=",
-            "dev": true
-        },
-        "is-gzip": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-            "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
-            "dev": true
-        },
-        "is-jpg": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-1.0.1.tgz",
-            "integrity": "sha1-KW1X/dmc4BBDSnKD40armhA16XU=",
-            "dev": true
-        },
-        "is-natural-number": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
-            "integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec=",
-            "dev": true
-        },
-        "is-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-            "dev": true
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
         },
         "is-plain-obj": {
             "version": "1.1.0",
@@ -4053,52 +3298,20 @@
             "dev": true,
             "requires": {
                 "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
             }
         },
-        "is-png": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
-            "integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84=",
-            "dev": true
-        },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
-        },
-        "is-redirect": {
+        "is-root": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-            "dev": true
-        },
-        "is-regex": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-            "dev": true,
-            "requires": {
-                "has": "1.0.1"
-            }
-        },
-        "is-relative": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-            "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
-            "dev": true
-        },
-        "is-retry-allowed": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-            "dev": true
+            "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+            "integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU="
         },
         "is-stream": {
             "version": "1.1.0",
@@ -4115,53 +3328,10 @@
                 "html-comment-regex": "1.1.1"
             }
         },
-        "is-symbol": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-            "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-            "dev": true
-        },
-        "is-tar": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
-            "integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0=",
-            "dev": true
-        },
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
-        },
-        "is-url": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-            "dev": true
-        },
-        "is-utf8": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-            "dev": true
-        },
-        "is-valid-glob": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-            "dev": true
-        },
-        "is-wsl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-            "dev": true
-        },
-        "is-zip": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
-            "integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU=",
-            "dev": true
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "is2": {
             "version": "0.0.9",
@@ -4170,14 +3340,6 @@
             "dev": true,
             "requires": {
                 "deep-is": "0.1.2"
-            },
-            "dependencies": {
-                "deep-is": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz",
-                    "integrity": "sha1-nO1l6gvAsJ9CptecGxkD+dkTzBg=",
-                    "dev": true
-                }
             }
         },
         "isarray": {
@@ -4193,10 +3355,13 @@
             "dev": true
         },
         "isobject": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-            "dev": true
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true,
+            "requires": {
+                "isarray": "1.0.0"
+            }
         },
         "isomorphic-fetch": {
             "version": "2.2.1",
@@ -4211,19 +3376,7 @@
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
-        },
-        "jpegtran-bin": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz",
-            "integrity": "sha1-9g7PSumZwL2tLp+83ytvCYHnops=",
-            "dev": true,
-            "requires": {
-                "bin-build": "2.2.0",
-                "bin-wrapper": "3.0.2",
-                "logalot": "2.1.0"
-            }
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "js-base64": {
             "version": "2.4.3",
@@ -4238,61 +3391,45 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-            "dev": true,
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+            "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
             "requires": {
                 "argparse": "1.0.10",
-                "esprima": "4.0.0"
-            },
-            "dependencies": {
-                "esprima": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-                    "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-                    "dev": true
-                }
+                "esprima": "2.7.3"
             }
         },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true,
             "optional": true
         },
         "jsesc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+            "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
             "dev": true
         },
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-            "dev": true
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-            "dev": true
-        },
-        "json-stable-stringify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "dev": true,
-            "requires": {
-                "jsonify": "0.0.0"
-            }
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
             "dev": true
         },
         "jsonfile": {
@@ -4307,14 +3444,12 @@
         "jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -4322,11 +3457,27 @@
                 "verror": "1.10.0"
             }
         },
+        "junk": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
+            "integrity": "sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI="
+        },
         "kind-of": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-            "dev": true
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true,
+            "requires": {
+                "is-buffer": "1.1.6"
+            }
+        },
+        "latest-version": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
+            "integrity": "sha1-ra+JjV8iOA0/nEU4bv3/ChtbdQE=",
+            "requires": {
+                "package-json": "0.2.0"
+            }
         },
         "lazy-cache": {
             "version": "2.0.2",
@@ -4335,21 +3486,6 @@
             "dev": true,
             "requires": {
                 "set-getter": "0.1.0"
-            }
-        },
-        "lazy-req": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
-            "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
-            "dev": true
-        },
-        "lazystream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.3.6"
             }
         },
         "list-item": {
@@ -4362,54 +3498,6 @@
                 "extend-shallow": "2.0.1",
                 "is-number": "2.1.0",
                 "repeat-string": "1.6.1"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "0.1.1"
-                    }
-                },
-                "is-number": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
-            }
-        },
-        "livereload-js": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
-            "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg==",
-            "dev": true
-        },
-        "load-json-file": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
             }
         },
         "locate-path": {
@@ -4422,102 +3510,51 @@
                 "path-exists": "3.0.0"
             }
         },
+        "lockfile": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+            "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+            "requires": {
+                "signal-exit": "3.0.2"
+            }
+        },
         "lodash": {
             "version": "4.17.10",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
             "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
             "dev": true
         },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-            "dev": true
+        "lodash._isnative": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
         },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-            "dev": true
+        "lodash._objecttypes": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+            "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
         },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-            "dev": true
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-            "dev": true
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-            "dev": true
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-            "dev": true
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-            "dev": true
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-            "dev": true
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-            "dev": true
-        },
-        "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "dev": true,
+        "lodash.debounce": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
+            "integrity": "sha1-2M6tJG7EuSbouFZ4/Dlr/rqMxvw=",
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash.isfunction": "2.4.1",
+                "lodash.isobject": "2.4.1",
+                "lodash.now": "2.4.1"
             }
         },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-            "dev": true
+        "lodash.isfunction": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+            "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE="
         },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-            "dev": true
-        },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-            "dev": true
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true,
+        "lodash.isobject": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+            "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._objecttypes": "2.4.1"
             }
         },
         "lodash.memoize": {
@@ -4526,11 +3563,13 @@
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
             "dev": true
         },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-            "dev": true
+        "lodash.now": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
+            "integrity": "sha1-aHIVZQBSUYX6+WeFu3/n/hW1YsY=",
+            "requires": {
+                "lodash._isnative": "2.4.1"
+            }
         },
         "lodash.uniq": {
             "version": "4.5.0",
@@ -4541,27 +3580,11 @@
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-            "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
+            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
                 "chalk": "2.4.1"
             }
-        },
-        "logalot": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
-            "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
-            "dev": true,
-            "requires": {
-                "figures": "1.7.0",
-                "squeak": "1.3.0"
-            }
-        },
-        "longest": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-            "dev": true
         },
         "loose-envify": {
             "version": "1.3.1",
@@ -4572,71 +3595,28 @@
                 "js-tokens": "3.0.2"
             }
         },
-        "loud-rejection": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-            "dev": true,
-            "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
-            }
-        },
-        "lowercase-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-            "dev": true
-        },
-        "lpad-align": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
-            "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
-            "dev": true,
-            "requires": {
-                "get-stdin": "4.0.1",
-                "indent-string": "2.1.0",
-                "longest": "1.0.1",
-                "meow": "3.7.0"
-            }
-        },
         "lru-cache": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-            "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+            "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
                 "pseudomap": "1.0.2",
                 "yallist": "2.1.2"
             }
         },
+        "lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+            "requires": {
+                "es5-ext": "0.10.44"
+            }
+        },
         "macaddress": {
             "version": "0.2.8",
             "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
             "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-            "dev": true
-        },
-        "make-dir": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-            "dev": true,
-            "requires": {
-                "pify": "3.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                }
-            }
-        },
-        "map-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
             "dev": true
         },
         "markdown-link": {
@@ -4685,41 +3665,30 @@
             "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
             "dev": true
         },
-        "mdn-data": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.2.tgz",
-            "integrity": "sha512-HUqqf4U+XdKomJXe2Chw+b1zPXFRUZ3bfUbrGLQ2TGwMOBRULuTHI9geusGqRL4WzsusnLLxYAxV4f/F/8wV+g==",
-            "dev": true
-        },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
         },
-        "meow": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-            "dev": true,
+        "memoizee": {
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
+            "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
             "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
+                "d": "0.1.1",
+                "es5-ext": "0.10.44",
+                "es6-weak-map": "0.1.4",
+                "event-emitter": "0.3.5",
+                "lru-queue": "0.1.0",
+                "next-tick": "0.2.2",
+                "timers-ext": "0.1.5"
             },
             "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
+                "next-tick": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                    "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
                 }
             }
         },
@@ -4728,15 +3697,6 @@
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
             "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
             "dev": true
-        },
-        "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.3.6"
-            }
         },
         "methods": {
             "version": "1.1.2",
@@ -4753,14 +3713,12 @@
         "mime-db": {
             "version": "1.33.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-            "dev": true
+            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
         },
         "mime-types": {
             "version": "2.1.18",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-            "dev": true,
             "requires": {
                 "mime-db": "1.33.0"
             }
@@ -4768,14 +3726,13 @@
         "mimic-fn": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
             "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-            "dev": true,
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
                 "brace-expansion": "1.1.11"
             }
@@ -4783,8 +3740,7 @@
         "minimist": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mixin-deep": {
             "version": "1.3.1",
@@ -4811,10 +3767,19 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             }
+        },
+        "mkpath": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+            "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE="
+        },
+        "mout": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz",
+            "integrity": "sha1-hPDz/WrMcxf2PeKv/cwM7gCbBHc="
         },
         "mri": {
             "version": "1.1.1",
@@ -4828,55 +3793,26 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "dev": true,
-            "requires": {
-                "duplexer2": "0.0.2"
-            },
-            "dependencies": {
-                "duplexer2": {
-                    "version": "0.0.2",
-                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                    "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.1.14"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
+        "mute-stream": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+            "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34="
+        },
+        "natives": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
+            "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
         },
         "negotiator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
             "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
             "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node-fetch": {
             "version": "1.7.3",
@@ -4888,22 +3824,12 @@
                 "is-stream": "1.1.0"
             }
         },
-        "node-status-codes": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-            "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-            "dev": true
-        },
-        "normalize-package-data": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-            "dev": true,
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "abbrev": "1.0.9"
             }
         },
         "normalize-path": {
@@ -4939,13 +3865,36 @@
                 "path-key": "2.0.1"
             }
         },
-        "nth-check": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-            "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-            "dev": true,
+        "npmconf": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.3.tgz",
+            "integrity": "sha512-iTK+HI68GceCoGOHAQiJ/ik1iDfI7S+cgyG8A+PP18IU3X83kRhQIRhAUNj4Bp2JMx6Zrt5kCiozYa9uGWTjhA==",
             "requires": {
-                "boolbase": "1.0.0"
+                "config-chain": "1.1.11",
+                "inherits": "2.0.3",
+                "ini": "1.3.5",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "once": "1.3.3",
+                "osenv": "0.1.0",
+                "safe-buffer": "5.1.2",
+                "semver": "4.3.6",
+                "uid-number": "0.0.5"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.3.3",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                    "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "semver": {
+                    "version": "4.3.6",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+                }
             }
         },
         "num2fraction": {
@@ -4963,40 +3912,12 @@
         "oauth-sign": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-            "dev": true
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
-        },
-        "object-keys": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-            "dev": true
-        },
-        "object.getownpropertydescriptors": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-            "dev": true,
-            "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.11.0"
-            }
-        },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
-            "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
-            }
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object.pick": {
             "version": "1.3.0",
@@ -5005,18 +3926,14 @@
             "dev": true,
             "requires": {
                 "isobject": "3.0.1"
-            }
-        },
-        "object.values": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-            "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-            "dev": true,
-            "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.11.0",
-                "function-bind": "1.1.1",
-                "has": "1.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
             }
         },
         "on-finished": {
@@ -5032,7 +3949,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1.0.2"
             }
@@ -5047,29 +3963,23 @@
             }
         },
         "opn": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-            "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-            "dev": true,
-            "requires": {
-                "is-wsl": "1.1.0"
-            }
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
+            "integrity": "sha1-uQlkM0bQChq8l3qLlvPOPFPVz18="
         },
-        "optipng-bin": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-3.1.4.tgz",
-            "integrity": "sha1-ldNPLEiHBPb9cGBr/qDGWfHZXYQ=",
-            "dev": true,
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "requires": {
-                "bin-build": "2.2.0",
-                "bin-wrapper": "3.0.2",
-                "logalot": "2.1.0"
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.2"
             }
         },
         "ora": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
-            "integrity": "sha1-iERYIVs6XUCXWSKF+TMhu3p54uU=",
+            "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
             "dev": true,
             "requires": {
                 "chalk": "2.4.1",
@@ -5078,33 +3988,46 @@
                 "log-symbols": "2.2.0"
             }
         },
-        "ordered-read-streams": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-            "dev": true,
-            "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.6"
-            }
-        },
-        "os-filter-obj": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
-            "integrity": "sha1-WRUzDZDs7VV9LZOKMcbdIU2cY60=",
-            "dev": true
-        },
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
+        "os-name": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+            "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
+            "requires": {
+                "osx-release": "1.1.0",
+                "win-release": "1.1.1"
+            }
+        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
+        },
+        "osenv": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz",
+            "integrity": "sha1-YWaBIe7FhJVQMLn0cLHSMJUEv8s="
+        },
+        "osx-release": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
+            "integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=",
+            "requires": {
+                "minimist": "1.2.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                }
+            }
         },
         "p-finally": {
             "version": "1.0.0",
@@ -5115,7 +4038,7 @@
         "p-limit": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-            "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
+            "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "dev": true,
             "requires": {
                 "p-try": "1.0.0"
@@ -5130,11 +4053,20 @@
                 "p-limit": "1.2.0"
             }
         },
-        "p-pipe": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
-            "integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k=",
-            "dev": true
+        "p-throttler": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.0.tgz",
+            "integrity": "sha1-GxaQeULDM+bx3eq8s0eSBLjEF8Q=",
+            "requires": {
+                "q": "0.9.7"
+            },
+            "dependencies": {
+                "q": {
+                    "version": "0.9.7",
+                    "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+                    "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
+                }
+            }
         },
         "p-try": {
             "version": "1.0.0",
@@ -5142,54 +4074,19 @@
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true
         },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
+        "package-json": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/package-json/-/package-json-0.2.0.tgz",
+            "integrity": "sha1-Axbhd7jrFJmF009wa0pVQ7J0vsU=",
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
-            }
-        },
-        "parse-json": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-            "dev": true,
-            "requires": {
-                "error-ex": "1.3.1"
+                "got": "0.3.0",
+                "registry-url": "0.1.1"
             }
         },
         "parseurl": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
             "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-            "dev": true
-        },
-        "path-dirname": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
             "dev": true
         },
         "path-exists": {
@@ -5222,48 +4119,65 @@
             "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
             "dev": true
         },
-        "path-type": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-            }
-        },
-        "pend": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-            "dev": true
-        },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-            "dev": true
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
-        "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
-        },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+        "postcss": {
+            "version": "5.2.18",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "chalk": "1.1.3",
+                "js-base64": "2.4.3",
+                "source-map": "0.5.7",
+                "supports-color": "3.2.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                            "dev": true
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
             }
         },
         "postcss-calc": {
@@ -5275,77 +4189,6 @@
                 "postcss": "5.2.18",
                 "postcss-message-helpers": "2.0.0",
                 "reduce-css-calc": "1.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-colormin": {
@@ -5357,77 +4200,6 @@
                 "colormin": "1.1.2",
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-convert-values": {
@@ -5438,77 +4210,6 @@
             "requires": {
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-discard-comments": {
@@ -5518,77 +4219,6 @@
             "dev": true,
             "requires": {
                 "postcss": "5.2.18"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-discard-duplicates": {
@@ -5598,77 +4228,6 @@
             "dev": true,
             "requires": {
                 "postcss": "5.2.18"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-discard-empty": {
@@ -5678,77 +4237,6 @@
             "dev": true,
             "requires": {
                 "postcss": "5.2.18"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-discard-overridden": {
@@ -5758,77 +4246,6 @@
             "dev": true,
             "requires": {
                 "postcss": "5.2.18"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-discard-unused": {
@@ -5839,77 +4256,6 @@
             "requires": {
                 "postcss": "5.2.18",
                 "uniqs": "2.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-filter-plugins": {
@@ -5920,77 +4266,6 @@
             "requires": {
                 "postcss": "5.2.18",
                 "uniqid": "4.1.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-merge-idents": {
@@ -6002,77 +4277,6 @@
                 "has": "1.0.1",
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-merge-longhand": {
@@ -6082,77 +4286,6 @@
             "dev": true,
             "requires": {
                 "postcss": "5.2.18"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-merge-rules": {
@@ -6168,83 +4301,14 @@
                 "vendors": "1.0.2"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
                 "browserslist": {
                     "version": "1.7.7",
                     "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000839",
-                        "electron-to-chromium": "1.3.45"
-                    }
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
+                        "caniuse-db": "1.0.30000841",
+                        "electron-to-chromium": "1.3.46"
                     }
                 }
             }
@@ -6264,77 +4328,6 @@
                 "object-assign": "4.1.1",
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-minify-gradients": {
@@ -6345,77 +4338,6 @@
             "requires": {
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-minify-params": {
@@ -6428,77 +4350,6 @@
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0",
                 "uniqs": "2.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-minify-selectors": {
@@ -6511,77 +4362,6 @@
                 "has": "1.0.1",
                 "postcss": "5.2.18",
                 "postcss-selector-parser": "2.2.3"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-normalize-charset": {
@@ -6591,77 +4371,6 @@
             "dev": true,
             "requires": {
                 "postcss": "5.2.18"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-normalize-url": {
@@ -6674,77 +4383,6 @@
                 "normalize-url": "1.9.1",
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-ordered-values": {
@@ -6755,77 +4393,6 @@
             "requires": {
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-reduce-idents": {
@@ -6836,77 +4403,6 @@
             "requires": {
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-reduce-initial": {
@@ -6916,77 +4412,6 @@
             "dev": true,
             "requires": {
                 "postcss": "5.2.18"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-reduce-transforms": {
@@ -6998,77 +4423,6 @@
                 "has": "1.0.1",
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-selector-parser": {
@@ -7092,77 +4446,6 @@
                 "postcss": "5.2.18",
                 "postcss-value-parser": "3.3.0",
                 "svgo": "0.7.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-unique-selectors": {
@@ -7174,77 +4457,6 @@
                 "alphanum-sort": "1.0.2",
                 "postcss": "5.2.18",
                 "uniqs": "2.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "postcss-value-parser": {
@@ -7262,83 +4474,12 @@
                 "has": "1.0.1",
                 "postcss": "5.2.18",
                 "uniqs": "2.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.3",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                }
             }
         },
         "precise-commits": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/precise-commits/-/precise-commits-1.0.2.tgz",
-            "integrity": "sha1-Rlm+AanDMQ9QzlHd+RP+rR18yUA=",
+            "integrity": "sha512-PYkoNTFXVvZRzJTDxdgzmPanhSNGj5Wtj2NgSo7IhwNXGcKktX+L4DJhyIrhFSLsWWAvd+cYyyU2eXlaX5QxzA==",
             "dev": true,
             "requires": {
                 "diff-match-patch": "1.0.1",
@@ -7354,12 +4495,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
             "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-            "dev": true
-        },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
             "dev": true
         },
         "prettier": {
@@ -7389,6 +4524,14 @@
                 "asap": "2.0.6"
             }
         },
+        "promptly": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+            "integrity": "sha1-c+8gD6gynV06jfQXmJULhkbKRtk=",
+            "requires": {
+                "read": "1.0.7"
+            }
+        },
         "prop-types": {
             "version": "15.6.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
@@ -7399,6 +4542,11 @@
                 "loose-envify": "1.3.1",
                 "object-assign": "4.1.1"
             }
+        },
+        "proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
         },
         "proxy-addr": {
             "version": "2.0.3",
@@ -7416,11 +4564,26 @@
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
             "dev": true
         },
+        "pump": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
+            "integrity": "sha1-rl/4wfk+2HrcZTCpdWWxJvWFRUs=",
+            "requires": {
+                "end-of-stream": "1.0.0",
+                "once": "1.2.0"
+            },
+            "dependencies": {
+                "once": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.2.0.tgz",
+                    "integrity": "sha1-3hkFxjavh0qPuoYtmqvd0fkgRhw="
+                }
+            }
+        },
         "punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-            "dev": true
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "q": {
             "version": "1.5.1",
@@ -7431,8 +4594,7 @@
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-            "dev": true
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "query-string": {
             "version": "4.3.4",
@@ -7459,6 +4621,12 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
                     "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
                     "dev": true
                 }
             }
@@ -7507,32 +4675,13 @@
                 }
             }
         },
-        "rc": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-            "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
-            "dev": true,
-            "requires": {
-                "deep-extend": "0.5.1",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
-            }
-        },
         "react": {
-            "version": "16.4.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
-            "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
+            "version": "15.6.2",
+            "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+            "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
             "dev": true,
             "requires": {
+                "create-react-class": "15.6.3",
                 "fbjs": "0.8.16",
                 "loose-envify": "1.3.1",
                 "object-assign": "4.1.1",
@@ -7540,9 +4689,9 @@
             }
         },
         "react-dom": {
-            "version": "16.4.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.0.tgz",
-            "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
+            "version": "15.6.2",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+            "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
             "dev": true,
             "requires": {
                 "fbjs": "0.8.16",
@@ -7551,56 +4700,18 @@
                 "prop-types": "15.6.1"
             }
         },
-        "read-all-stream": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-            "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-            "dev": true,
-            "requires": {
-                "pinkie-promise": "2.0.1",
-                "readable-stream": "2.3.6"
-            }
+        "react-dom-factories": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/react-dom-factories/-/react-dom-factories-1.0.2.tgz",
+            "integrity": "sha1-63cFxNs2+1AbOqOP91lhaqD/luA=",
+            "dev": true
         },
-        "read-pkg": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-            "dev": true,
+        "read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
-            }
-        },
-        "read-pkg-up": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-            "dev": true,
-            "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                    "dev": true,
-                    "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
-                    }
-                },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true,
-                    "requires": {
-                        "pinkie-promise": "2.0.1"
-                    }
-                }
+                "mute-stream": "0.0.4"
             }
         },
         "readable-stream": {
@@ -7618,6 +4729,30 @@
                 "util-deprecate": "1.0.2"
             }
         },
+        "readline2": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+            "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+            "requires": {
+                "mute-stream": "0.0.4",
+                "strip-ansi": "2.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                    "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+                },
+                "strip-ansi": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                    "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+                    "requires": {
+                        "ansi-regex": "1.1.1"
+                    }
+                }
+            }
+        },
         "rechoir": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -7627,24 +4762,18 @@
                 "resolve": "1.7.1"
             }
         },
-        "redent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-            "dev": true,
+        "redeyed": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+            "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
             "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
+                "esprima": "1.0.4"
             },
             "dependencies": {
-                "strip-indent": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                    "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-                    "dev": true,
-                    "requires": {
-                        "get-stdin": "4.0.1"
-                    }
+                "esprima": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                    "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
                 }
             }
         },
@@ -7707,15 +4836,6 @@
                 "private": "0.1.8"
             }
         },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "0.1.3"
-            }
-        },
         "regexpu-core": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
@@ -7725,6 +4845,14 @@
                 "regenerate": "1.4.0",
                 "regjsgen": "0.2.0",
                 "regjsparser": "0.1.5"
+            }
+        },
+        "registry-url": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
+            "integrity": "sha1-FzlCe4GxELMCSCocfNcn/8yC1b4=",
+            "requires": {
+                "npmconf": "2.1.3"
             }
         },
         "regjsgen": {
@@ -7740,14 +4868,6 @@
             "dev": true,
             "requires": {
                 "jsesc": "0.5.0"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-                    "dev": true
-                }
             }
         },
         "remarkable": {
@@ -7772,12 +4892,6 @@
                 }
             }
         },
-        "remove-trailing-separator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-            "dev": true
-        },
         "repeat-element": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -7799,17 +4913,10 @@
                 "is-finite": "1.0.2"
             }
         },
-        "replace-ext": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-            "dev": true
-        },
         "request": {
-            "version": "2.87.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-            "dev": true,
+            "version": "2.86.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
+            "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
             "requires": {
                 "aws-sign2": "0.7.0",
                 "aws4": "1.7.0",
@@ -7819,6 +4926,7 @@
                 "forever-agent": "0.6.1",
                 "form-data": "2.3.2",
                 "har-validator": "5.0.3",
+                "hawk": "6.0.2",
                 "http-signature": "1.2.0",
                 "is-typedarray": "1.0.0",
                 "isstream": "0.1.2",
@@ -7831,6 +4939,22 @@
                 "tough-cookie": "2.3.4",
                 "tunnel-agent": "0.6.0",
                 "uuid": "3.2.1"
+            }
+        },
+        "request-progress": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.0.tgz",
+            "integrity": "sha1-vfIGK/wZfF1JJQDUTLOv94ZbSS4=",
+            "requires": {
+                "throttleit": "0.0.2"
+            }
+        },
+        "request-replay": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
+            "integrity": "sha1-m2k6XRGLOfXFlurV7ZGiZEQFf2A=",
+            "requires": {
+                "retry": "0.6.0"
             }
         },
         "resolve": {
@@ -7852,26 +4976,25 @@
                 "signal-exit": "3.0.2"
             }
         },
+        "retry": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+            "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc="
+        },
         "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-            "dev": true,
-            "requires": {
-                "glob": "7.1.2"
-            }
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+            "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+        },
+        "rx": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
+            "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY="
         },
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
-        },
-        "safe-json-parse": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
-            "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "sax": {
             "version": "1.2.4",
@@ -7879,45 +5002,24 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
             "dev": true
         },
-        "seek-bzip": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-            "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
-            "dev": true,
-            "requires": {
-                "commander": "2.8.1"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-readlink": "1.0.1"
-                    }
-                }
-            }
-        },
         "semver": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-            "dev": true
+            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         },
-        "semver-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-            "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
-            "dev": true
-        },
-        "semver-truncate": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
-            "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
-            "dev": true,
+        "semver-diff": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-0.1.0.tgz",
+            "integrity": "sha1-T2BXyj66I8xIS1H2Sq+IsTGjhV0=",
             "requires": {
-                "semver": "5.5.0"
+                "semver": "2.3.2"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+                    "integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI="
+                }
             }
         },
         "send": {
@@ -7962,12 +5064,6 @@
                 "to-object-path": "0.3.0"
             }
         },
-        "set-immediate-shim": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-            "dev": true
-        },
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -7995,6 +5091,17 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
+        "shell-quote": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+            "integrity": "sha1-lSxE4LHtkBPvU5WBecxkPod3Rms=",
+            "requires": {
+                "array-filter": "0.0.1",
+                "array-map": "0.0.0",
+                "array-reduce": "0.0.0",
+                "jsonify": "0.0.0"
+            }
+        },
         "shelljs": {
             "version": "0.7.8",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
@@ -8006,11 +5113,15 @@
                 "rechoir": "0.6.2"
             }
         },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-            "dev": true
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "simple-swizzle": {
             "version": "0.2.2",
@@ -8037,6 +5148,14 @@
             "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
             "dev": true
         },
+        "sntp": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+            "requires": {
+                "hoek": "4.2.1"
+            }
+        },
         "sort-keys": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -8046,6 +5165,12 @@
                 "is-plain-obj": "1.1.0"
             }
         },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
         "source-map-support": {
             "version": "0.4.18",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
@@ -8053,112 +5178,17 @@
             "dev": true,
             "requires": {
                 "source-map": "0.5.7"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                }
             }
-        },
-        "sparkles": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
-            "dev": true
-        },
-        "spdx-correct": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-            "dev": true,
-            "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
-            }
-        },
-        "spdx-exceptions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
-            "dev": true
-        },
-        "spdx-expression-parse": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-            "dev": true,
-            "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
-            }
-        },
-        "spdx-license-ids": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
-            "dev": true
         },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
-        },
-        "squeak": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
-            "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "console-stream": "0.1.1",
-                "lpad-align": "1.1.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "sshpk": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-            "dev": true,
             "requires": {
                 "asn1": "0.2.3",
                 "assert-plus": "1.0.0",
@@ -8170,38 +5200,10 @@
                 "tweetnacl": "0.14.5"
             }
         },
-        "stable": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-            "dev": true
-        },
-        "stat-mode": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-            "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
-            "dev": true
-        },
         "statuses": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
             "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-            "dev": true
-        },
-        "stream-combiner2": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-            "dev": true,
-            "requires": {
-                "duplexer2": "0.1.4",
-                "readable-stream": "2.3.6"
-            }
-        },
-        "stream-shift": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
             "dev": true
         },
         "strict-uri-encode": {
@@ -8210,11 +5212,28 @@
             "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
             "dev": true
         },
-        "string-template": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-            "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
-            "dev": true
+        "string-length": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
+            "integrity": "sha1-qwS7M4Z+50vu1/uJu38InTkngPI=",
+            "requires": {
+                "strip-ansi": "0.2.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.1.0.tgz",
+                    "integrity": "sha1-Vcpg22kAhXxCOukpeYACb5Qe2QM="
+                },
+                "strip-ansi": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.2.2.tgz",
+                    "integrity": "sha1-hU0pDJgVJfyMOXqRCwJa4tVP/Ag=",
+                    "requires": {
+                        "ansi-regex": "0.1.0"
+                    }
+                }
+            }
         },
         "string_decoder": {
             "version": "1.1.1",
@@ -8225,23 +5244,23 @@
                 "safe-buffer": "5.1.2"
             }
         },
-        "strip-bom": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
-            "requires": {
-                "is-utf8": "0.2.1"
-            }
+        "stringify-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz",
+            "integrity": "sha1-htNefb+86apFY31+zdeEfhWduKI="
         },
-        "strip-bom-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+        "stringstream": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+            "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-color": {
@@ -8249,62 +5268,6 @@
             "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
             "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s=",
             "dev": true
-        },
-        "strip-dirs": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
-            "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "get-stdin": "4.0.1",
-                "is-absolute": "0.1.7",
-                "is-natural-number": "2.1.1",
-                "minimist": "1.2.0",
-                "sum-up": "1.0.3"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
         },
         "strip-eof": {
             "version": "1.0.0",
@@ -8318,70 +5281,10 @@
             "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
             "dev": true
         },
-        "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "dev": true
-        },
-        "strip-outer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "1.0.5"
-            }
-        },
-        "sum-up": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
-            "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
-        },
         "supports-color": {
             "version": "5.4.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
             "dev": true,
             "requires": {
                 "has-flag": "3.0.0"
@@ -8400,33 +5303,50 @@
                 "mkdirp": "0.5.1",
                 "sax": "1.2.4",
                 "whet.extend": "0.9.9"
-            },
-            "dependencies": {
-                "js-yaml": {
-                    "version": "3.7.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-                    "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "2.7.3"
-                    }
-                }
+            }
+        },
+        "tar-fs": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.5.2.tgz",
+            "integrity": "sha1-D1lCS+fu7kUjIxbjAvZtP26m2z4=",
+            "requires": {
+                "mkdirp": "0.5.1",
+                "pump": "0.3.5",
+                "tar-stream": "0.4.7"
             }
         },
         "tar-stream": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-            "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
-            "dev": true,
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+            "integrity": "sha1-Hx0s6evHtCdlJDyg6PG3v9oKrc0=",
             "requires": {
-                "bl": "1.2.2",
-                "buffer-alloc": "1.1.0",
-                "end-of-stream": "1.4.1",
-                "fs-constants": "1.0.0",
-                "readable-stream": "2.3.6",
-                "to-buffer": "1.1.1",
+                "bl": "0.9.5",
+                "end-of-stream": "1.0.0",
+                "readable-stream": "1.1.14",
                 "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
             }
         },
         "tcp-port-used": {
@@ -8454,104 +5374,29 @@
                 }
             }
         },
-        "temp-dir": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-            "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-            "dev": true
+        "throttleit": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+            "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8="
         },
-        "tempfile": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
-            "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
-            "dev": true,
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "timers-ext": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.5.tgz",
+            "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
             "requires": {
-                "temp-dir": "1.0.0",
-                "uuid": "3.2.1"
+                "es5-ext": "0.10.44",
+                "next-tick": "1.0.0"
             }
         },
-        "through2": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
-            }
-        },
-        "through2-filter": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-            "dev": true,
-            "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
-            }
-        },
-        "time-stamp": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-            "dev": true
-        },
-        "timed-out": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-            "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
-            "dev": true
-        },
-        "tiny-lr": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
-            "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
-            "dev": true,
-            "requires": {
-                "body": "5.1.0",
-                "debug": "3.1.0",
-                "faye-websocket": "0.10.0",
-                "livereload-js": "2.3.0",
-                "object-assign": "4.1.1",
-                "qs": "6.5.2"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
-            }
-        },
-        "to-absolute-glob": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-            "dev": true,
-            "requires": {
-                "extend-shallow": "2.0.1"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "0.1.1"
-                    }
-                }
-            }
-        },
-        "to-buffer": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-            "dev": true
+        "tmp": {
+            "version": "0.0.23",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz",
+            "integrity": "sha1-3odKpel0qF8KMs39vXRmPLO9nHQ="
         },
         "to-fast-properties": {
             "version": "1.0.3",
@@ -8566,17 +5411,6 @@
             "dev": true,
             "requires": {
                 "kind-of": "3.2.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
             }
         },
         "toml": {
@@ -8585,38 +5419,36 @@
             "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
             "dev": true
         },
+        "touch": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
+            "integrity": "sha1-plp3d5Xly74SmUmb3EIoH/shtfQ=",
+            "requires": {
+                "nopt": "1.0.10"
+            },
+            "dependencies": {
+                "nopt": {
+                    "version": "1.0.10",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+                    "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+                    "requires": {
+                        "abbrev": "1.0.9"
+                    }
+                }
+            }
+        },
         "tough-cookie": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-            "dev": true,
             "requires": {
                 "punycode": "1.4.1"
             }
         },
-        "tree-node-cli": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/tree-node-cli/-/tree-node-cli-1.2.1.tgz",
-            "integrity": "sha512-4x3NJfAJSJqzj983yFnjxJyjzDHZUR3g4NukBb/LiV/kNLpUgZJ/bQk688Mq2xgTJznZOmIAN3ZqPqWnTKX9Cw==",
-            "dev": true,
-            "requires": {
-                "commander": "2.15.1"
-            }
-        },
-        "trim-newlines": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-            "dev": true
-        },
-        "trim-repeated": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-            "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "1.0.5"
-            }
+        "traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
         },
         "trim-right": {
             "version": "1.0.1",
@@ -8628,7 +5460,6 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dev": true,
             "requires": {
                 "safe-buffer": "5.1.2"
             }
@@ -8637,7 +5468,6 @@
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true,
             "optional": true
         },
         "type-is": {
@@ -8661,6 +5491,42 @@
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
             "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
             "dev": true
+        },
+        "uglify-js": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+            "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+            "optional": true,
+            "requires": {
+                "async": "0.2.10",
+                "optimist": "0.3.7",
+                "source-map": "0.1.43"
+            },
+            "dependencies": {
+                "optimist": {
+                    "version": "0.3.7",
+                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                    "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                    "optional": true,
+                    "requires": {
+                        "wordwrap": "0.0.2"
+                    }
+                },
+                "source-map": {
+                    "version": "0.1.43",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                    "optional": true,
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                }
+            }
+        },
+        "uid-number": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+            "integrity": "sha1-Wj2yPvXb1VuB/ODsmirG/M3ruB4="
         },
         "underscore": {
             "version": "1.7.0",
@@ -8695,16 +5561,6 @@
             "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
             "dev": true
         },
-        "unique-stream": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-            "dev": true,
-            "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
-            }
-        },
         "universalify": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -8717,17 +5573,62 @@
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
             "dev": true
         },
-        "unquote": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-            "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-            "dev": true
-        },
-        "unzip-response": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-            "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-            "dev": true
+        "update-notifier": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.0.tgz",
+            "integrity": "sha1-oBDJKK3PAgkLjgzn/vb7Cnysw0o=",
+            "requires": {
+                "chalk": "0.5.1",
+                "configstore": "0.3.2",
+                "latest-version": "0.2.0",
+                "semver-diff": "0.1.0",
+                "string-length": "0.1.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                    "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+                },
+                "ansi-styles": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                    "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+                },
+                "chalk": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                    "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+                    "requires": {
+                        "ansi-styles": "1.1.0",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "0.1.0",
+                        "strip-ansi": "0.3.0",
+                        "supports-color": "0.2.0"
+                    }
+                },
+                "has-ansi": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                    "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                    "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                    "requires": {
+                        "ansi-regex": "0.2.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                    "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+                }
+            }
         },
         "url-join": {
             "version": "1.1.0",
@@ -8735,39 +5636,16 @@
             "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
             "dev": true
         },
-        "url-parse-lax": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-            "dev": true,
-            "requires": {
-                "prepend-http": "1.0.4"
-            }
-        },
-        "url-regex": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
-            "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
-            "dev": true,
-            "requires": {
-                "ip-regex": "1.0.3"
-            }
+        "user-home": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+            "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
         },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true
-        },
-        "util.promisify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-            "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-            "dev": true,
-            "requires": {
-                "define-properties": "1.1.2",
-                "object.getownpropertydescriptors": "2.0.3"
-            }
         },
         "utils-merge": {
             "version": "1.0.1",
@@ -8778,24 +5656,7 @@
         "uuid": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-            "dev": true
-        },
-        "vali-date": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-            "dev": true
-        },
-        "validate-npm-package-license": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-            "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-            "dev": true,
-            "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
-            }
+            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         },
         "vary": {
             "version": "1.1.2",
@@ -8813,91 +5674,11 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
                 "extsprintf": "1.3.0"
             }
-        },
-        "vinyl": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-            "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-            "dev": true,
-            "requires": {
-                "clone": "1.0.4",
-                "clone-stats": "0.0.1",
-                "replace-ext": "0.0.1"
-            },
-            "dependencies": {
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                }
-            }
-        },
-        "vinyl-assign": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
-            "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
-            "dev": true,
-            "requires": {
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.6"
-            }
-        },
-        "vinyl-fs": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-            "dev": true,
-            "requires": {
-                "duplexify": "3.6.0",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
-                "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.6",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
-            }
-        },
-        "ware": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
-            "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
-            "dev": true,
-            "requires": {
-                "wrap-fn": "0.1.5"
-            }
-        },
-        "websocket-driver": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-            "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-            "dev": true,
-            "requires": {
-                "http-parser-js": "0.4.13",
-                "websocket-extensions": "0.1.3"
-            }
-        },
-        "websocket-extensions": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-            "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-            "dev": true
         },
         "whatwg-fetch": {
             "version": "2.0.4",
@@ -8914,34 +5695,37 @@
         "which": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-            "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
                 "isexe": "2.0.0"
             }
         },
-        "wrap-fn": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
-            "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
-            "dev": true,
+        "win-release": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+            "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
             "requires": {
-                "co": "3.1.0"
-            },
-            "dependencies": {
-                "co": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-                    "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
-                    "dev": true
-                }
+                "semver": "5.5.0"
             }
+        },
+        "wordwrap": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
         },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "xdg-basedir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
+            "integrity": "sha1-FP+PY6T9vLBdW27qIrNvMDO58E4=",
+            "requires": {
+                "user-home": "1.1.1"
+            }
         },
         "xml": {
             "version": "1.0.1",
@@ -8952,8 +5736,7 @@
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-            "dev": true
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "yallist": {
             "version": "2.1.2",
@@ -8971,14 +5754,13 @@
                 "glob": "7.1.2"
             }
         },
-        "yauzl": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-            "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+        "yargs": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-2.3.0.tgz",
+            "integrity": "sha1-6QDIclDsXNCA22AJ/j3WMVbx1/s=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "wordwrap": "0.0.2"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
         "url": "https://github.com/humphd/next/issues"
     },
     "homepage": "https://github.com/humphd/next#readme",
+    "dependencies": {
+        "filer": "humphd/filer#9p-filer"
+    },
     "devDependencies": {
         "docusaurus": "^1.0.15",
         "husky": "^0.14.3",


### PR DESCRIPTION
I've been working on updating Filer to work with our Linux VM and the 9P fs sharing in v86.  It's pretty much done.  The branch is at https://github.com/humphd/filer/tree/9p-filer.  I'm talking with the upstream Filer maintainer to see about landing it there; but until then, we can do it this way.

I've also fixed #59 (we need to confirm).

This will add Filer in `node_modules`, and it can be `required()` either as is, or using the built version in `dist/filer.js` or `dist/filer.min.js`.

