### PR TITLE
Fix base URL for Bramble StartupState so vfs URLs get rewritten correctly for edtior.html

### DIFF
--- a/src/editor/src/bramble/StartupState.js
+++ b/src/editor/src/bramble/StartupState.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
     _url = Map({
         origin: window.location.origin,
         host: window.location.host,
-        base: window.location.origin + window.location.pathname.replace(/\/index.html*$/, "/")
+        base: window.location.origin + window.location.pathname.replace(/\/editor.html*$/, "/")
     });
 
 });


### PR DESCRIPTION
@twigz20 see if this fixes your bug with the live dev not working correctly.  I think this should correct the URLs for the sw cache, since it used to assume `index.html` and we changed to `editor.html`.