### PR TITLE
Allowing user to use /data/download and /data/upload, /data/reset. Fixes #22, #23, #24, #94

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ sudo: false
 cache: 
   directories:
     # cache the larger node_modules we use throughout the tree 
-    - "node_modules"
-    - "src/editor/node_modules"
-    - "src/website/node_modules"
+    # - "node_modules"
+    # - "src/editor/node_modules"
+    # - "src/website/node_modules"
     # cache the bios, linux binary images
     - "dist/terminal/bin"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12812,7 +12812,7 @@
             "dev": true
         },
         "v86": {
-            "version": "github:humphd/v86#fe4464d02fd50cacc0d1108af5ed7471d3d15ff3"
+            "version": "github:humphd/v86#84086ae0998ff1fb64dc606a1b7d4cad91ebc735"
         },
         "validate-npm-package-license": {
             "version": "3.0.3",

--- a/src/db/db-mutation.html
+++ b/src/db/db-mutation.html
@@ -3,28 +3,41 @@
 
 <head>
     <meta charset="utf-8">
-    <h1 draggable="true">Drag and drop UI for DB upload.</h1>
+    <h1 draggable="true">Drag and drop UI for DB upload, download and reset.</h1>
     <script src="./drag-drop.js"></script>
     <link rel="stylesheet" href="styles.css">
 </head>
 
 <body>
-    <div style="display: inline; overflow: visible; position: relative;">
-        <div id="drop-zone" class="drop-zone">
-            Drop files here...
-            <input type="file" name="file" id="file" />
+    <div class="container">
+        <div class="upload-container">
+            <h3>Drag and drop file(s) or click below. If multiple files are supplied, only the last one will be accepted.</h3>
+            <div id="drop-zone" class="drop-zone">
+                Drop files here...
+                <input type="file" name="file" id="file" />
+            </div>
+            <br>
+            <div class="controls">
+                <button id="upload">Upload</button>
+                <button id="clear">Clear</button>
+            </div>
         </div>
         <div class="vl"></div>
         <div class="download-container">
+            <h3>Click below to download a JSON version of the database.</h3>
             <a id="downloadAnchorElem" style="display:none"></a>
             <button id="download">Download</button>
         </div>
+        <div class="vl"></div>
+        <div class="delete-container">
+            <h3>Click below to clear database (db is not deleted, but emptied).</h3>
+            <button id="delete">Delete</button>
+        </div>
     </div>
-    <div class="controls">
-        <button id="upload">Upload</button>
-        <button id="clear">Clear</button>
-    </div>
-    <p id="result"></p>
+    <hr>
+    <h3> Result:
+        <span id="result"></span>
+    </h3>
 </body>
 
 </html>

--- a/src/db/db-mutation.html
+++ b/src/db/db-mutation.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <h1 draggable="true">Drag and drop UI for DB upload.</h1>
+    <script src="./drag-drop.js"></script>
+    <link rel="stylesheet" href="styles.css">
+</head>
+
+<body>
+    <div style="display: inline; overflow: visible; position: relative;">
+        <div id="drop-zone" class="drop-zone">
+            Drop files here...
+            <input type="file" name="file" id="file" />
+        </div>
+        <div class="vl"></div>
+        <div class="download-container">
+            <a id="downloadAnchorElem" style="display:none"></a>
+            <button id="download">Download</button>
+        </div>
+    </div>
+    <div class="controls">
+        <button id="upload">Upload</button>
+        <button id="clear">Clear</button>
+    </div>
+    <p id="result"></p>
+</body>
+
+</html>

--- a/src/db/db-mutation.html
+++ b/src/db/db-mutation.html
@@ -18,7 +18,7 @@
             </div>
             <br>
             <div class="controls">
-                <button id="upload">Upload</button>
+                <button id="upload">Import</button>
                 <button id="clear">Clear</button>
             </div>
         </div>
@@ -31,7 +31,7 @@
         <div class="vl"></div>
         <div class="delete-container">
             <h3>Click below to clear database (db is not deleted, but emptied).</h3>
-            <button id="delete">Delete</button>
+            <button id="delete">Reset</button>
         </div>
     </div>
     <hr>

--- a/src/db/drag-drop.js
+++ b/src/db/drag-drop.js
@@ -4,6 +4,7 @@ window.addEventListener('load', () => {
     const uploadButton = document.getElementById('upload');
     const clearButton = document.getElementById('clear');
     const downloadButton = document.getElementById('download');
+    const deleteButton = document.getElementById('delete');
     const dlAnchorElem = document.getElementById('downloadAnchorElem');
 
     // intialize drag and drop zone
@@ -25,10 +26,9 @@ window.addEventListener('load', () => {
             fileInput.files = e.dataTransfer.files;
         }
         if (fileInput.files.length) {
-            container.textContent =
-                fileInput.files.length > 1
-                    ? `Received ${fileInput.files.length} files.`
-                    : `Received ${fileInput.files.item(0).name}`;
+            container.textContent = `Received ${
+                fileInput.files.item(fileInput.files.length - 1).name
+            }`;
         }
         e.preventDefault();
     };
@@ -41,6 +41,8 @@ window.addEventListener('load', () => {
     // attempt to upload the file. NOTE only the last file is used, if multiple files are droped.
     uploadButton.onclick = () => {
         if (!fileInput.files.length) {
+            document.getElementById('result').innerText =
+                'Please supply a file before attempting an upload.';
             return;
         }
 
@@ -71,7 +73,11 @@ window.addEventListener('load', () => {
                     return res.json();
                 })
                 .then(data => {
-                    document.getElementById('result').innerText = data.query;
+                    if (!data.ok) {
+                        throw `Unable to upload. ${data.message}`;
+                    }
+                    document.getElementById('result').innerText =
+                        'Succesfully uploaded.';
                 })
                 .catch(err => {
                     document.getElementById('result').innerText = err;
@@ -103,7 +109,11 @@ window.addEventListener('load', () => {
                 return res.json();
             })
             .then(data => {
-                document.getElementById('result').innerText = 'Success';
+                if (!data.ok) {
+                    throw `Unable to download. ${data.message}`;
+                }
+                document.getElementById('result').innerText =
+                    'Successfully downloaded.';
                 const dataStr =
                     'data:text/json;charset=utf-8,' +
                     encodeURIComponent(JSON.stringify(data.query));
@@ -111,6 +121,31 @@ window.addEventListener('load', () => {
                 dlAnchorElem.setAttribute('href', dataStr);
                 dlAnchorElem.setAttribute('download', 'db.json');
                 dlAnchorElem.click();
+            })
+            .catch(err => {
+                document.getElementById('result').innerText = err;
+            });
+    };
+
+    deleteButton.onclick = () => {
+        fetch(
+            new Request(encodeURI('/data/reset'), {
+                method: 'GET',
+                body: null,
+            })
+        )
+            .then(res => {
+                if (!res.ok) {
+                    throw `${res.status}. ${res.statusText} for ${res.url}`;
+                }
+                return res.json();
+            })
+            .then(data => {
+                if (!data.ok) {
+                    throw `Unable to reset. ${data.message}`;
+                }
+                document.getElementById('result').innerText =
+                    'Succesfully deleted.';
             })
             .catch(err => {
                 document.getElementById('result').innerText = err;

--- a/src/db/drag-drop.js
+++ b/src/db/drag-drop.js
@@ -130,7 +130,7 @@ window.addEventListener('load', () => {
     deleteButton.onclick = () => {
         fetch(
             new Request(encodeURI('/data/reset'), {
-                method: 'GET',
+                method: 'DELETE',
                 body: null,
             })
         )

--- a/src/db/drag-drop.js
+++ b/src/db/drag-drop.js
@@ -1,0 +1,119 @@
+window.addEventListener('load', () => {
+    const container = document.getElementById('drop-zone');
+    const fileInput = document.getElementById('file');
+    const uploadButton = document.getElementById('upload');
+    const clearButton = document.getElementById('clear');
+    const downloadButton = document.getElementById('download');
+    const dlAnchorElem = document.getElementById('downloadAnchorElem');
+
+    // intialize drag and drop zone
+    container.ondragover = container.ondragenter = e => {
+        e.preventDefault();
+    };
+
+    container.onmouseenter = () => {
+        container.classList.add('mouse-over');
+    };
+
+    container.onmouseleave = () => {
+        container.classList.remove('mouse-over');
+    };
+
+    // reuse the same function for file input field change and zone drop events
+    container.ondrop = fileInput.onchange = e => {
+        if (e.dataTransfer) {
+            fileInput.files = e.dataTransfer.files;
+        }
+        if (fileInput.files.length) {
+            container.textContent =
+                fileInput.files.length > 1
+                    ? `Received ${fileInput.files.length} files.`
+                    : `Received ${fileInput.files.item(0).name}`;
+        }
+        e.preventDefault();
+    };
+
+    // trigger file browsing on click of the zone
+    container.onclick = () => {
+        fileInput.click();
+    };
+
+    // attempt to upload the file. NOTE only the last file is used, if multiple files are droped.
+    uploadButton.onclick = () => {
+        if (!fileInput.files.length) {
+            return;
+        }
+
+        const file = fileInput.files.item(fileInput.files.length - 1);
+
+        if (file.type !== 'application/json') {
+            document.getElementById('result').innerText =
+                'Only JSON files are accepted as valid upload target.';
+            return;
+        }
+
+        const reader = new FileReader();
+
+        // This fires after the blob has been read/loaded.
+        reader.onload = e => {
+            const text = e.srcElement.result;
+
+            fetch(
+                new Request(encodeURI('/data/upload'), {
+                    method: 'POST',
+                    body: text,
+                })
+            )
+                .then(res => {
+                    if (!res.ok) {
+                        throw `${res.status}. ${res.statusText} for ${res.url}`;
+                    }
+                    return res.json();
+                })
+                .then(data => {
+                    document.getElementById('result').innerText = data.query;
+                })
+                .catch(err => {
+                    document.getElementById('result').innerText = err;
+                });
+        };
+
+        // Start reading the blob as text.
+        reader.readAsText(file.slice());
+    };
+
+    // clear file input field from any files
+    clearButton.onclick = () => {
+        fileInput.value = '';
+        container.textContent = 'Drop files here...';
+    };
+
+    // attempt to download database schema into a json file
+    downloadButton.onclick = () => {
+        fetch(
+            new Request(encodeURI('/data/download'), {
+                method: 'GET',
+                body: null,
+            })
+        )
+            .then(res => {
+                if (!res.ok) {
+                    throw `${res.status}. ${res.statusText} for ${res.url}`;
+                }
+                return res.json();
+            })
+            .then(data => {
+                document.getElementById('result').innerText = 'Success';
+                const dataStr =
+                    'data:text/json;charset=utf-8,' +
+                    encodeURIComponent(JSON.stringify(data.query));
+
+                dlAnchorElem.setAttribute('href', dataStr);
+                dlAnchorElem.setAttribute('download', 'db.json');
+                dlAnchorElem.click();
+            })
+            .catch(err => {
+                document.getElementById('result').innerText = err;
+            });
+    };
+});

--- a/src/db/index.html
+++ b/src/db/index.html
@@ -7,7 +7,6 @@
 </head>
 
 <body>
-    <script src="./index.js"></script>
     <script src="./process.js"></script>
     <div>
         <div>

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -215,12 +215,12 @@ export default class {
                     data: await table.toArray(),
                 };
             }
+            return rc;
         } catch (err) {
             err.message = `Unable to download ${this.db.name}.
             ${err.message}`;
             throw err;
         }
-        return rc;
     }
 
     async upload(bulk) {

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -217,8 +217,7 @@ export default class {
             }
         } catch (err) {
             err.message = `Unable to download ${this.db.name}.
-            ${err.message}
-            `;
+            ${err.message}`;
             throw err;
         }
         return rc;

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -200,7 +200,7 @@ export default class {
         }
     }
 
-    async downloadDb() {
+    async download() {
         await this.openDB();
         const rc = {};
         try {
@@ -224,7 +224,7 @@ export default class {
         return rc;
     }
 
-    async uploadDb(bulk) {
+    async upload(bulk) {
         const tables = Object.keys(bulk);
         const dbSchema = {};
         tables.forEach(table => {
@@ -238,7 +238,6 @@ export default class {
         this.db.version(this.version).stores(dbSchema);
 
         // create a new instance
-        // await this.openDB();
         await this.db.open();
 
         tables.forEach(table => {

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -231,10 +231,9 @@ export default class {
             dbSchema[table] = bulk[table].schema;
         });
         // clear old version of the db
-        this.db.close();
-        await this.db.delete();
+        await this.delete();
 
-        this.version++;
+        this.version = 1;
         this.db.version(this.version).stores(dbSchema);
 
         // create a new instance
@@ -243,5 +242,14 @@ export default class {
         tables.forEach(table => {
             this.db[table].bulkAdd(bulk[table].data);
         });
+    }
+
+    async delete(createNew = false) {
+        this.db.close();
+        await this.db.delete();
+
+        if (createNew) {
+            await this.openDB();
+        }
     }
 }

--- a/src/db/process.js
+++ b/src/db/process.js
@@ -3,7 +3,7 @@ const submitForm = () => {
     const bodyElement = window.document.getElementById('body');
     const methodElement = document.getElementById('method');
 
-    let url = `${window.location.hostname}/data/api/`;
+    let url = `${window.location.hostname}`;
 
     let body =
         // @ts-ignore

--- a/src/db/routes.js
+++ b/src/db/routes.js
@@ -26,7 +26,7 @@ export default (workbox, db) => {
             }
             return new Response(JSON.stringify({ ok: ok, query: message }));
         },
-        'GET'
+        'DELETE'
     );
 
     workbox.routing.registerRoute(

--- a/src/db/routes.js
+++ b/src/db/routes.js
@@ -3,9 +3,7 @@ const pathFromUrl = (url, match = '') => {
     return url.substr(url.indexOf(match) + match.length + 1).split('/');
 };
 // endpoints to be trimmed from urls
-const apiUrl = 'data/api',
-    uploadUrl = 'data/upload',
-    downloadUrl = 'data/download';
+const apiUrl = 'data/api';
 
 // regex to match different endpoints
 const apiRegex = /\/data\/api.*/,
@@ -36,10 +34,10 @@ export default (workbox, db) => {
         uploadRegex,
         async ({ event }) => {
             return event.request.json().then(async payload => {
-                let message = null;
+                let message = 'Success';
                 let ok = true;
                 try {
-                    message = await db.uploadDb(payload);
+                    await db.uploadDb(payload);
                 } catch (err) {
                     console.error(err);
                     message = err.message;

--- a/src/db/routes.js
+++ b/src/db/routes.js
@@ -8,9 +8,27 @@ const apiUrl = 'data/api';
 // regex to match different endpoints
 const apiRegex = /\/data\/api.*/,
     uploadRegex = /\/data\/upload.*/,
-    downloadRegex = /\/data\/download.*/;
+    downloadRegex = /\/data\/download.*/,
+    resetRegex = /\/data\/reset.*/;
 
 export default (workbox, db) => {
+    workbox.routing.registerRoute(
+        resetRegex,
+        async () => {
+            let message = null;
+            let ok = true;
+            try {
+                message = await db.delete(true);
+            } catch (err) {
+                console.error(err);
+                message = err.message;
+                ok = false;
+            }
+            return new Response(JSON.stringify({ ok: ok, query: message }));
+        },
+        'GET'
+    );
+
     workbox.routing.registerRoute(
         downloadRegex,
         async () => {
@@ -23,9 +41,7 @@ export default (workbox, db) => {
                 message = err.message;
                 ok = false;
             }
-            return new Response(
-                JSON.stringify({ ok: ok, query: message, method: 'GET' })
-            );
+            return new Response(JSON.stringify({ ok: ok, query: message }));
         },
         'GET'
     );
@@ -34,7 +50,7 @@ export default (workbox, db) => {
         uploadRegex,
         async ({ event }) => {
             return event.request.json().then(async payload => {
-                let message = 'Success';
+                let message = null;
                 let ok = true;
                 try {
                     await db.upload(payload);
@@ -43,9 +59,7 @@ export default (workbox, db) => {
                     message = err.message;
                     ok = false;
                 }
-                return new Response(
-                    JSON.stringify({ ok: ok, query: message, method: 'POST' })
-                );
+                return new Response(JSON.stringify({ ok: ok, query: message }));
             });
         },
         'POST'
@@ -69,9 +83,7 @@ export default (workbox, db) => {
                 message = err.message;
                 ok = false;
             }
-            return new Response(
-                JSON.stringify({ ok: ok, query: message, method: 'GET' })
-            );
+            return new Response(JSON.stringify({ ok: ok, query: message }));
         },
         'GET'
     );
@@ -95,9 +107,7 @@ export default (workbox, db) => {
                     message = err.message;
                     ok = false;
                 }
-                return new Response(
-                    JSON.stringify({ ok: ok, query: message, method: 'POST' })
-                );
+                return new Response(JSON.stringify({ ok: ok, query: message }));
             });
         },
         'POST'
@@ -123,9 +133,7 @@ export default (workbox, db) => {
                     message = err.message;
                     ok = false;
                 }
-                return new Response(
-                    JSON.stringify({ ok: ok, query: message, method: 'PUT' })
-                );
+                return new Response(JSON.stringify({ ok: ok, query: message }));
             });
         },
         'PUT'
@@ -149,9 +157,7 @@ export default (workbox, db) => {
                 message = err.message;
                 ok = false;
             }
-            return new Response(
-                JSON.stringify({ ok: ok, query: message, method: 'DELETE' })
-            );
+            return new Response(JSON.stringify({ ok: ok, query: message }));
         },
         'DELETE'
     );

--- a/src/db/routes.js
+++ b/src/db/routes.js
@@ -17,7 +17,7 @@ export default (workbox, db) => {
             let message = null;
             let ok = true;
             try {
-                message = await db.downloadDb();
+                message = await db.download();
             } catch (err) {
                 console.error(err);
                 message = err.message;
@@ -37,7 +37,7 @@ export default (workbox, db) => {
                 let message = 'Success';
                 let ok = true;
                 try {
-                    await db.uploadDb(payload);
+                    await db.upload(payload);
                 } catch (err) {
                     console.error(err);
                     message = err.message;

--- a/src/db/styles.css
+++ b/src/db/styles.css
@@ -1,7 +1,6 @@
 .drop-zone {
     /*Sort of important*/
-    width: 47%;
-    display: inline-block;
+    width: 100%;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
@@ -28,6 +27,7 @@ input {
 }
 
 button {
+    height: 20px;
     margin: 10px;
 }
 
@@ -38,13 +38,34 @@ button {
 
 .vl {
     border-left: 2px solid grey;
-    height: 200px;
-    display: inline-block;
     margin-left: 2%;
     margin-right: 2%;
 }
 
-.download-container {
-    display: inline-block;
+.upload-container,
+.download-container,
+.delete-container {
+    flex-direction: column;
+}
+
+.upload-container {
     width: 47%;
+}
+
+.download-container,
+.delete-container {
+    width: 20%;
+}
+
+html,
+body {
+    height: 100%;
+}
+
+.container {
+    overflow: visible;
+    position: relative;
+    vertical-align: top;
+    display: flex;
+    width: 100%;
 }

--- a/src/db/styles.css
+++ b/src/db/styles.css
@@ -1,0 +1,50 @@
+.drop-zone {
+    /*Sort of important*/
+    width: 47%;
+    display: inline-block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    /*Sort of important*/
+    height: 200px;
+    border: 2px dashed rgba(0, 0, 0, 0.3);
+    border-radius: 20px;
+    font-family: Arial;
+    text-align: center;
+    position: relative;
+    line-height: 180px;
+    font-size: 20px;
+    color: rgba(0, 0, 0, 0.3);
+}
+/*Important*/
+.drop-zone.mouse-over {
+    border: 2px dashed rgba(0, 0, 0, 0.5);
+    color: rgba(0, 0, 0, 0.5);
+    cursor: pointer;
+}
+
+input {
+    display: none;
+}
+
+button {
+    margin: 10px;
+}
+
+.controls {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+.vl {
+    border-left: 2px solid grey;
+    height: 200px;
+    display: inline-block;
+    margin-left: 2%;
+    margin-right: 2%;
+}
+
+.download-container {
+    display: inline-block;
+    width: 47%;
+}

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -3,7 +3,7 @@ export default {
         // Cache main docs content
         workbox.routing.registerRoute(
             /\b(blog|css|docs|en|img).*/,
-            workbox.strategies.networkFirst()
+            workbox.strategies.staleWhileRevalidate()
         );
     },
 };

--- a/src/docs/index.js
+++ b/src/docs/index.js
@@ -3,7 +3,7 @@ export default {
         // Cache main docs content
         workbox.routing.registerRoute(
             /\b(blog|css|docs|en|img).*/,
-            workbox.strategies.cacheFirst()
+            workbox.strategies.networkFirst()
         );
     },
 };

--- a/src/index.html
+++ b/src/index.html
@@ -2,9 +2,14 @@
 <title>Unbundled</title>
 
 <ul>
-    <li><a href="/www/">/www</a> - browse files</li>
-    <li><a href="/terminal/">/terminal</a> - boot Linux VM</li>
-    <li><a href="/editor/">/editor</a> - edit files</li>
+    <li>
+        <a href="/www/">/www</a> - browse files</li>
+    <li>
+        <a href="/terminal/">/terminal</a> - boot Linux VM</li>
+    <li>
+        <a href="/editor/">/editor</a> - edit files</li>
+    <li>
+        <a href="./db/index.html">/data</a> - REST API into indexed.db</li>
 </ul>
 
 <script src="sw.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,8 @@
         <a href="/editor/">/editor</a> - edit files</li>
     <li>
         <a href="./db/index.html">/data</a> - REST API into indexed.db</li>
+    <li>
+        <a href="./db/db-mutation.html">/data/upload-download</a> - Upload and download UI.</li>
 </ul>
 
 <script src="sw.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
     <li>
         <a href="./db/index.html">/data</a> - REST API into indexed.db</li>
     <li>
-        <a href="./db/db-mutation.html">/data/upload-download</a> - Upload and download UI.</li>
+        <a href="./db/db-mutation.html">/data/{upload,download,reset}</a> - Reset, upload and download database.</li>
 </ul>
 
 <script src="sw.js"></script>

--- a/src/web-server/routes.js
+++ b/src/web-server/routes.js
@@ -6,7 +6,7 @@ export default (workbox, webServer) => {
     // Cache service-worker icon files (PNG) in the root
     workbox.routing.registerRoute(
         /[^/]+\.png/,
-        workbox.strategies.cacheFirst()
+        workbox.strategies.staleWhileRevalidate()
     );
 
     // @ts-ignore

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -27,7 +27,9 @@ function waitForServiceWorkers() {
                         resolve();
                     } else {
                         reg.onupdatefound = () => {
-                            setTimeout(resolve, 1000);
+                            // simulate passage of time inside browser,
+                            // so that service worker can install on the next tick.
+                            setTimeout(resolve, 10);
                         };
                     }
                 })

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -2,8 +2,55 @@ const port = require('../jest-puppeteer.config').server.port;
 const timeout = 10000;
 jest.setTimeout(timeout);
 
+const domain = 'http://localhost:' + port;
+
+async function populateTable(url, requests, page) {
+    for (let req of requests) {
+        await makeRequest(
+            url,
+            {
+                method: 'PUT',
+                body: JSON.stringify(req),
+            },
+            page
+        );
+    }
+}
+
+function waitForServiceWorkers() {
+    return navigator.serviceWorker.getRegistrations().then(registrations => {
+        const promises = [];
+        registrations.forEach(reg => {
+            promises.push(
+                new Promise(resolve => {
+                    if (reg.active) {
+                        resolve();
+                    } else {
+                        reg.onupdatefound = () => {
+                            setTimeout(resolve, 1000);
+                        };
+                    }
+                })
+            );
+        });
+        return Promise.all(promises);
+    });
+}
+
+function makeRequest(url, config, page) {
+    return page.evaluate(
+        (url, req) =>
+            fetch(url, req)
+                .then(res => res.json())
+                .catch(err => err),
+        encodeURI(url),
+        config
+    );
+}
+// it is essential that the order of the top level describes is mainained,
+// because of the async nature of indexed db and speed of puppeteer.
+// indexed db does not keep up with puppeteer's instructions, which might create race conditions because of db blocks.
 describe('Testing /data/api/ endpoint', () => {
-    const domain = 'http://localhost:' + port;
     const endpoint = 'data/api';
     let page = null;
 
@@ -13,31 +60,22 @@ describe('Testing /data/api/ endpoint', () => {
         [{ data: { my: 'test', a: 3 }, schema: '++a' }, 'test2'],
     ];
 
-    async function populateTable(url, requests) {
-        for (let req of requests) {
-            await makeRequest(url, {
-                method: 'PUT',
-                body: JSON.stringify(req),
-            });
-        }
-    }
-
-    function makeRequest(url, config) {
-        return page.evaluate(
-            (url, req) =>
-                fetch(url, req)
-                    .then(res => res.json())
-                    .catch(err => err),
-            url,
-            config
-        );
-    }
-
     beforeAll(async () => {
         page = (await browser.pages())[0];
         await page.goto(domain, { waitUntil: 'networkidle0' });
         // wait until service worker installs
-        await page.waitFor(1000);
+        // await page.evaluate(waitForServiceWorkers);
+        await page.waitFor(2000);
+    });
+
+    afterAll(async () => {
+        // clear indexed db before finishing
+        const response = await makeRequest(
+            `${domain}/data/reset`,
+            { method: 'DELETE' },
+            page
+        );
+        expect(response.ok).toBeTruthy();
     });
 
     describe('Testing POST', () => {
@@ -45,12 +83,14 @@ describe('Testing /data/api/ endpoint', () => {
             'Create table with body = %j for table %s',
             async (body, tableName) => {
                 const response = await makeRequest(
-                    encodeURI(`${domain}/${endpoint}/${tableName}`),
+                    `${domain}/${endpoint}/${tableName}`,
                     {
                         method: 'POST',
                         body: JSON.stringify(body),
-                    }
+                    },
+                    page
                 );
+                //
                 expect(response.ok).toBeTruthy();
             }
         );
@@ -62,12 +102,12 @@ describe('Testing /data/api/ endpoint', () => {
                     data: { _id: 1, my: 'test', a: 3 },
                 }),
             };
-            const url = encodeURI(`${domain}/${endpoint}/test3`);
-            let response = await makeRequest(url, req);
+            const url = `${domain}/${endpoint}/test3`;
+            let response = await makeRequest(url, req, page);
             // first insertion should be fine.
             expect(response.ok).toBeTruthy();
 
-            response = await makeRequest(url, req);
+            response = await makeRequest(url, req, page);
             // duplicate key inserted, should fail.
             expect(response.ok).toBeFalsy();
         });
@@ -78,11 +118,12 @@ describe('Testing /data/api/ endpoint', () => {
             'Create table with body = %j for table %s',
             async (body, tableName) => {
                 const response = await makeRequest(
-                    encodeURI(`${domain}/${endpoint}/${tableName}`),
+                    `${domain}/${endpoint}/${tableName}`,
                     {
                         method: 'PUT',
                         body: JSON.stringify(body),
-                    }
+                    },
+                    page
                 );
                 expect(response.ok).toBeTruthy();
             }
@@ -99,14 +140,14 @@ describe('Testing /data/api/ endpoint', () => {
                     schema: schema,
                 }),
             };
-            const url = encodeURI(`${domain}/${endpoint}/test4`);
-            let response = await makeRequest(url, req);
+            const url = `${domain}/${endpoint}/test4`;
+            let response = await makeRequest(url, req, page);
             // first insertion should be fine.
             expect(response.ok).toBeTruthy();
 
             payload.my = 'some other text';
 
-            response = await makeRequest(url, req);
+            response = await makeRequest(url, req, page);
             // update should succeed, since using PUT.
             expect(response.ok).toBeTruthy();
         });
@@ -131,17 +172,22 @@ describe('Testing /data/api/ endpoint', () => {
                 },
             ];
 
-            await populateTable(`${domain}/${endpoint}/${tableName}`, requests);
+            await populateTable(
+                `${domain}/${endpoint}/${tableName}`,
+                requests,
+                page
+            );
         });
 
         test('Table that does not exist.', async () => {
             const response = await makeRequest(
                 // we allow empty table names
-                encodeURI(`${domain}/${endpoint}`),
+                `${domain}/${endpoint}`,
                 {
                     method: 'GET',
                     body: null,
-                }
+                },
+                page
             );
             expect(response.ok).toBeFalsy();
         });
@@ -152,11 +198,12 @@ describe('Testing /data/api/ endpoint', () => {
             `${tableName}/first_name/Jeremy`,
         ])('Table extraction using url: %s', async path => {
             const response = await makeRequest(
-                encodeURI(`${domain}/${endpoint}/${path}`),
+                `${domain}/${endpoint}/${path}`,
                 {
                     method: 'GET',
                     body: null,
-                }
+                },
+                page
             );
             expect(response.ok).toBeTruthy();
         });
@@ -180,21 +227,196 @@ describe('Testing /data/api/ endpoint', () => {
                 },
             ];
 
-            await populateTable(`${domain}/${endpoint}/${tableName}`, requests);
+            await populateTable(
+                `${domain}/${endpoint}/${tableName}`,
+                requests,
+                page
+            );
         });
 
         test.each([`${tableName}/last_name/Palpatine`, `${tableName}`])(
             'Delete from table using url: %s',
             async path => {
                 const response = await makeRequest(
-                    encodeURI(`${domain}/${endpoint}/${path}`),
+                    `${domain}/${endpoint}/${path}`,
                     {
                         method: 'DELETE',
                         body: null,
-                    }
+                    },
+                    page
                 );
+
                 expect(response.ok).toBeTruthy();
             }
         );
+    });
+});
+
+describe('Testing /data/download', () => {
+    let page = null;
+    const endpoint = 'data/download';
+
+    beforeAll(async () => {
+        page = (await browser.pages())[0];
+        await page.goto(domain, { waitUntil: 'networkidle0' });
+        // wait until service worker installs
+        await page.evaluate(waitForServiceWorkers);
+
+        //populate table with some data
+        await populateTable(
+            `${domain}/data/api/jedis1`,
+            [
+                {
+                    data: {
+                        name: 'Yoda',
+                        lightsaber: 'green',
+                    },
+                    schema: '_id,name,lightsaber',
+                },
+                {
+                    data: {
+                        name: 'Obi-Wan',
+                        lightsaber: 'blue',
+                    },
+                    schema: '_id,name,lightsaber',
+                },
+                {
+                    data: {
+                        name: 'Master Windu',
+                        lightsaber: 'purple',
+                    },
+                    schema: '_id,name,lightsaber',
+                },
+            ],
+            page
+        );
+    });
+
+    afterAll(async () => {
+        // clear indexed db before finishing
+        const response = await makeRequest(
+            `${domain}/data/reset`,
+            { method: 'DELETE' },
+            page
+        );
+
+        expect(response.ok).toBeTruthy();
+    });
+
+    test('Trying to download a db.', async () => {
+        let response = await makeRequest(
+            `${domain}/${endpoint}`,
+            {
+                method: 'GET',
+            },
+            page
+        );
+        expect(response.ok).toBeTruthy();
+    });
+});
+
+describe('Testing /data/reset', () => {
+    let page = null;
+    const endpoint = 'data/reset';
+
+    beforeAll(async () => {
+        page = (await browser.pages())[0];
+        await page.goto(domain, { waitUntil: 'networkidle0' });
+        // wait until service worker installs
+        await page.evaluate(waitForServiceWorkers);
+
+        //populate table with some data
+        await populateTable(
+            `${domain}/data/api/jedis`,
+            [
+                {
+                    data: {
+                        name: 'Yoda',
+                        lightsaber: 'green',
+                    },
+                    schema: '_id,name,lightsaber',
+                },
+                {
+                    data: {
+                        name: 'Obi-Wan',
+                        lightsaber: 'blue',
+                    },
+                    schema: '_id,name,lightsaber',
+                },
+                {
+                    data: {
+                        name: 'Master Windu',
+                        lightsaber: 'purple',
+                    },
+                    schema: '_id,name,lightsaber',
+                },
+            ],
+            page
+        );
+    });
+
+    test('Trying to delete an entire database.', async () => {
+        let response = await makeRequest(
+            `${domain}/${endpoint}`,
+            {
+                method: 'DELETE',
+            },
+            page
+        );
+
+        expect(response.ok).toBeTruthy();
+    });
+});
+
+describe('Testing /data/upload', () => {
+    let page = null;
+    const endpoint = 'data/upload';
+
+    beforeAll(async () => {
+        page = (await browser.pages())[0];
+        await page.goto(domain, { waitUntil: 'networkidle0' });
+        // wait until service worker installs
+        await page.evaluate(waitForServiceWorkers);
+    });
+
+    afterAll(async () => {
+        // clear indexed db before finishing
+        const response = await makeRequest(
+            `${domain}/data/reset`,
+            { method: 'DELETE' },
+            page
+        );
+
+        expect(response.ok).toBeTruthy();
+    });
+
+    test('Trying to upload a db.', async () => {
+        let response = await makeRequest(
+            `${domain}/${endpoint}`,
+            {
+                method: 'POST',
+                body: JSON.stringify({
+                    grandTour1: {
+                        schema: '++_id,first_name,last_name',
+                        data: [
+                            { first_name: 'James', last_name: 'May', _id: 1 },
+                            {
+                                first_name: 'Richard',
+                                last_name: 'Hammond',
+                                _id: 2,
+                            },
+                            {
+                                first_name: 'Jeremy',
+                                last_name: 'Clarkson',
+                                _id: 3,
+                            },
+                        ],
+                    },
+                }),
+            },
+            page
+        );
+
+        expect(response.ok).toBeTruthy();
     });
 });

--- a/tests/lib/shared.js
+++ b/tests/lib/shared.js
@@ -1,0 +1,52 @@
+const port = require('../../jest-puppeteer.config').server.port;
+
+module.exports.domain = 'http://localhost:' + port;
+
+function makeRequest(url, config, page) {
+    return page.evaluate(
+        (url, req) =>
+            fetch(url, req)
+                .then(res => res.json())
+                .catch(err => err),
+        encodeURI(url),
+        config
+    );
+}
+
+module.exports.makeRequest = makeRequest;
+
+module.exports.populateTable = async function(url, requests, page) {
+    for (let req of requests) {
+        await makeRequest(
+            url,
+            {
+                method: 'PUT',
+                body: JSON.stringify(req),
+            },
+            page
+        );
+    }
+};
+
+module.exports.waitForServiceWorkers = function(page) {
+    return page.evaluate(() =>
+        navigator.serviceWorker.getRegistrations().then(registrations => {
+            return Promise.all(
+                registrations.map(
+                    reg =>
+                        new Promise(resolve => {
+                            if (reg.active) {
+                                resolve();
+                            } else {
+                                reg.onupdatefound = () => {
+                                    // simulate passage of time inside browser,
+                                    // so that service worker can install on the next tick.
+                                    setTimeout(resolve, 10);
+                                };
+                            }
+                        })
+                )
+            );
+        })
+    );
+};


### PR DESCRIPTION
Revealing `/data/reset`, `/data/upload` and `/data/download` endpoints to allow DB backup and restore from dump.

Produced dump response is in json format:
```js
    {
        "tableName": {
            "schema": "",
            "data": [] // array of objects that represent data inside the table
        },
        "tableName": {
            "schema": "",
            "data": [] // array of objects that represent data inside the table
        }
    }
```

* `/data/download` is a `GET` request
* `/data/upload` is a `POST` where body is an object in the shape described above.
* `/data/reset` is a `DELETE` request.

Fixing #22, #24 and #23

Also fixes our caching strategy as proposed in #94  