### PR TITLE
adding json output to /www route endpoint. Fixes #95

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1888,7 +1888,7 @@
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
             "requires": {
                 "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
@@ -2313,7 +2313,7 @@
         "ci-info": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-            "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+            "integrity": "sha1-cQGTJkuwXHe4yQ0C9aryIhamZ7I=",
             "dev": true
         },
         "cipher-base": {
@@ -2414,7 +2414,7 @@
         "cli-spinners": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-            "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+            "integrity": "sha1-ACwZkJEtDVlYDJO9NsBW3pnkJZo=",
             "dev": true
         },
         "cli-width": {
@@ -2505,7 +2505,7 @@
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
             "dev": true,
             "requires": {
                 "color-name": "1.1.3"
@@ -3297,7 +3297,7 @@
         "diff-match-patch": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.1.tgz",
-            "integrity": "sha512-A0QEhr4PxGUMEtKxd6X+JLnOTFd3BfIPSDpsc4dMvj+CbSaErDwTpoTo/nFJDMSrjxLW4BiNq+FbNisAAHhWeQ==",
+            "integrity": "sha1-1fiAIT2C+8Ek0rlREfs8Az261/o=",
             "dev": true
         },
         "diffie-hellman": {
@@ -3907,7 +3907,7 @@
         "execa": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-            "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+            "integrity": "sha1-rbfOYs+YUHH2BYDetKiLnjRxLQE=",
             "dev": true,
             "requires": {
                 "cross-spawn": "5.1.0",
@@ -5602,7 +5602,7 @@
         "husky": {
             "version": "0.14.3",
             "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-            "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+            "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
             "dev": true,
             "requires": {
                 "is-ci": "1.1.0",
@@ -5625,7 +5625,7 @@
         "ignore": {
             "version": "3.3.8",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-            "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+            "integrity": "sha1-P46cNdOHCKOn4Omrtsc+fudweys=",
             "dev": true
         },
         "import-local": {
@@ -5918,7 +5918,7 @@
         "is-ci": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-            "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+            "integrity": "sha1-JH5BYueGDOu9rzC3dNawrH3P56U=",
             "dev": true,
             "requires": {
                 "ci-info": "1.1.3"
@@ -7236,7 +7236,7 @@
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
             "dev": true,
             "requires": {
                 "chalk": "2.4.1"
@@ -7541,7 +7541,7 @@
         "mimic-fn": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
             "dev": true
         },
         "minimalistic-assert": {
@@ -8018,7 +8018,7 @@
         "ora": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
-            "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
+            "integrity": "sha1-iERYIVs6XUCXWSKF+TMhu3p54uU=",
             "dev": true,
             "requires": {
                 "chalk": "2.4.1",
@@ -8111,7 +8111,7 @@
         "p-limit": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-            "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+            "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
             "dev": true,
             "requires": {
                 "p-try": "1.0.0"
@@ -10326,7 +10326,7 @@
         "precise-commits": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/precise-commits/-/precise-commits-1.0.2.tgz",
-            "integrity": "sha512-PYkoNTFXVvZRzJTDxdgzmPanhSNGj5Wtj2NgSo7IhwNXGcKktX+L4DJhyIrhFSLsWWAvd+cYyyU2eXlaX5QxzA==",
+            "integrity": "sha1-Rlm+AanDMQ9QzlHd+RP+rR18yUA=",
             "dev": true,
             "requires": {
                 "diff-match-patch": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
         "build-server": "parcel build src/index.html",
         "build-vm": "node tools/download-vm.js",
         "prebuild-terminal": "npm run build-vm",
-        "build-terminal": "parcel build src/terminal/index.html --public-url /terminal --out-dir dist/terminal",
+        "build-terminal":
+            "parcel build src/terminal/index.html --public-url /terminal --out-dir dist/terminal",
         "eslint": "eslint --fix .",
         "v86:setup": "docker build -t buildroot .",
-        "v86:bash": "cross-env OVERRIDE_CONFIG_DIR=1 node tools/build-v86 -ti --entrypoint \"bash\"",
+        "v86:bash":
+            "cross-env OVERRIDE_CONFIG_DIR=1 node tools/build-v86 -ti --entrypoint \"bash\"",
         "v86:build": "node tools/build-v86"
     },
     "repository": {

--- a/src/web-server/html-formatter.js
+++ b/src/web-server/html-formatter.js
@@ -1,4 +1,4 @@
-import { isMedia, isImage } from './content-type';
+import { isMedia, isImage, getMimeType } from './content-type';
 import iconImage from './icons/image2.png';
 import iconFolder from './icons/folder.png';
 import iconMovie from './icons/movie.png';
@@ -57,82 +57,89 @@ const formatRow = (
 };
 
 const footerClose = '<address>nohost/0.0.2 (Web)</address></body></html>';
+export default class {
+    /**
+     * Send an Apache-style 404
+     */
+    format404(url) {
+        return {
+            body: `<!DOCTYPE html>
+                <html><head>
+                <title>404 Not Found</title>
+                </head><body>
+                <h1>Not Found</h1>
+                <p>The requested URL ${url} was not found on this server.</p>
+                <hr>${footerClose}`,
+            type: 'text/html',
+            status: 404,
+        };
+    }
 
-/**
- * Send an Apache-style 404
- */
-export const format404 = url => {
-    return {
-        body: `<!DOCTYPE html>
-            <html><head>
-            <title>404 Not Found</title>
-            </head><body>
-            <h1>Not Found</h1>
-            <p>The requested URL ${url} was not found on this server.</p>
-            <hr>${footerClose}`,
-        type: 'text/html',
-    };
-};
+    /**
+     * Send an Apache-style directory listing
+     */
+    formatDir(dirPath, entries) {
+        const parent = path.dirname(dirPath);
 
-export const format404AsJson = url => {
-    return {
-        body: `The requested URL ${url} was not found on this server.`,
-        type: 'application/json',
-    };
-};
+        const header = `<!DOCTYPE html>
+                        <html><head><title>Index of ${dirPath}</title></head>
+                        <body><h1>Index of ${dirPath}</h1>
+                        <table><tr><th><img src="${iconBlank}" alt="[ICO]"></th>
+                        <th><b>Name</b></th><th><b>Last modified</b></th>
+                        <th><b>Size</b></th><th><b>Description</b></th></tr>
+                        <tr><th colspan="5"><hr></th></tr>
+                        <tr><td valign="top"><img src="${iconBack}" alt="[DIR]"></td>
+                        <td><a href="/www${parent}">Parent Directory</a></td><td>&nbsp;</td>
+                        <td align="right">  - </td><td>&nbsp;</td></tr>`;
 
-/**
- * Send an Apache-style directory listing
- */
-export const formatDir = (dirPath, entries) => {
-    const parent = path.dirname(dirPath);
+        const footer = `<tr><th colspan="5"><hr></th></tr></table>${footerClose}`;
 
-    const header = `<!DOCTYPE html>
-                    <html><head><title>Index of ${dirPath}</title></head>
-                    <body><h1>Index of ${dirPath}</h1>
-                    <table><tr><th><img src="${iconBlank}" alt="[ICO]"></th>
-                    <th><b>Name</b></th><th><b>Last modified</b></th>
-                    <th><b>Size</b></th><th><b>Description</b></th></tr>
-                    <tr><th colspan="5"><hr></th></tr>
-                    <tr><td valign="top"><img src="${iconBack}" alt="[DIR]"></td>
-                    <td><a href="/www${parent}">Parent Directory</a></td><td>&nbsp;</td>
-                    <td align="right">  - </td><td>&nbsp;</td></tr>`;
+        const rows = entries
+            .map(entry => {
+                const ext = path.extname(entry.name);
+                const href = '/www' + path.join(dirPath, entry.name);
+                let icon;
+                let alt;
 
-    const footer = `<tr><th colspan="5"><hr></th></tr></table>${footerClose}`;
-
-    const rows = entries
-        .map(entry => {
-            const ext = path.extname(entry.name);
-            const href = '/www' + path.join(dirPath, entry.name);
-            let icon;
-            let alt;
-
-            if (entry.type === 'DIRECTORY') {
-                icon = iconFolder;
-                alt = '[DIR]';
-            } else {
-                if (isImage(ext)) {
-                    icon = iconImage;
-                    alt = '[IMG]';
-                } else if (isMedia(ext)) {
-                    icon = iconMovie;
-                    alt = '[MOV]';
+                if (entry.type === 'DIRECTORY') {
+                    icon = iconFolder;
+                    alt = '[DIR]';
                 } else {
-                    icon = iconText;
-                    alt = '[TXT]';
+                    if (isImage(ext)) {
+                        icon = iconImage;
+                        alt = '[IMG]';
+                    } else if (isMedia(ext)) {
+                        icon = iconMovie;
+                        alt = '[MOV]';
+                    } else {
+                        icon = iconText;
+                        alt = '[TXT]';
+                    }
                 }
-            }
 
-            return formatRow(
-                icon,
-                alt,
-                href,
-                entry.name,
-                entry.mtime,
-                entry.size
-            );
-        })
-        .join('\n');
+                return formatRow(
+                    icon,
+                    alt,
+                    href,
+                    entry.name,
+                    entry.mtime,
+                    entry.size
+                );
+            })
+            .join('\n');
 
-    return header + rows + footer;
-};
+        return {
+            type: 'text/html',
+            status: 200,
+            body: header + rows + footer,
+        };
+    }
+
+    formatFile(path, content) {
+        return {
+            body: content,
+            type: getMimeType(path),
+            status: 200,
+        };
+    }
+}

--- a/src/web-server/html-formatter.js
+++ b/src/web-server/html-formatter.js
@@ -62,13 +62,23 @@ const footerClose = '<address>nohost/0.0.2 (Web)</address></body></html>';
  * Send an Apache-style 404
  */
 export const format404 = url => {
-    return `<!DOCTYPE html>
+    return {
+        body: `<!DOCTYPE html>
             <html><head>
             <title>404 Not Found</title>
             </head><body>
             <h1>Not Found</h1>
             <p>The requested URL ${url} was not found on this server.</p>
-            <hr>${footerClose}`;
+            <hr>${footerClose}`,
+        type: 'text/html',
+    };
+};
+
+export const format404AsJson = url => {
+    return {
+        body: `The requested URL ${url} was not found on this server.`,
+        type: 'application/json',
+    };
 };
 
 /**

--- a/src/web-server/html-formatter.js
+++ b/src/web-server/html-formatter.js
@@ -57,11 +57,11 @@ const formatRow = (
 };
 
 const footerClose = '<address>nohost/0.0.2 (Web)</address></body></html>';
-export default class {
+export default {
     /**
      * Send an Apache-style 404
      */
-    format404(url) {
+    format404: url => {
         return {
             body: `<!DOCTYPE html>
                 <html><head>
@@ -73,12 +73,12 @@ export default class {
             type: 'text/html',
             status: 404,
         };
-    }
+    },
 
     /**
      * Send an Apache-style directory listing
      */
-    formatDir(dirPath, entries) {
+    formatDir: (dirPath, entries) => {
         const parent = path.dirname(dirPath);
 
         const header = `<!DOCTYPE html>
@@ -133,13 +133,13 @@ export default class {
             status: 200,
             body: header + rows + footer,
         };
-    }
+    },
 
-    formatFile(path, content) {
+    formatFile: ({ path, content }) => {
         return {
             body: content,
             type: getMimeType(path),
             status: 200,
         };
-    }
-}
+    },
+};

--- a/src/web-server/index.js
+++ b/src/web-server/index.js
@@ -1,8 +1,6 @@
 import fs from '../lib/fs';
 const sh = new fs.Shell();
 
-import { getMimeType } from './content-type';
-import { formatDir } from './html-formatter';
 import registerRoute from './routes';
 
 export default class {
@@ -10,7 +8,7 @@ export default class {
         registerRoute(workbox, this);
     }
 
-    async serve(path) {
+    serve(path, formatter) {
         // TODO: need to add promises to Filer
         return new Promise((resolve, reject) => {
             fs.stat(path, (err, stats) => {
@@ -24,20 +22,14 @@ export default class {
                         if (err) {
                             return reject(err);
                         }
-                        resolve({
-                            type: 'text/html',
-                            body: formatDir(path, entries),
-                        });
+                        resolve(formatter.formatDir(path, entries));
                     });
                 } else {
-                    fs.readFile(path, (err, contents) => {
+                    fs.readFile(path, async (err, contents) => {
                         if (err) {
                             return reject(err);
                         }
-                        resolve({
-                            type: getMimeType(path),
-                            body: contents,
-                        });
+                        resolve(await formatter.formatFile(path, contents));
                     });
                 }
             });

--- a/src/web-server/index.js
+++ b/src/web-server/index.js
@@ -25,11 +25,17 @@ export default class {
                         resolve(formatter.formatDir(path, entries));
                     });
                 } else {
-                    fs.readFile(path, async (err, contents) => {
+                    fs.readFile(path, async (err, content) => {
                         if (err) {
                             return reject(err);
                         }
-                        resolve(await formatter.formatFile(path, contents));
+                        resolve(
+                            formatter.formatFile({
+                                path,
+                                content,
+                                stats,
+                            })
+                        );
                     });
                 }
             });

--- a/src/web-server/json-formatter.js
+++ b/src/web-server/json-formatter.js
@@ -1,34 +1,25 @@
-import fs from '../lib/fs';
-
-export default class {
-    format404(url) {
+export default {
+    format404: url => {
         return {
             body: `The requested URL ${url} was not found on this server.`,
             type: 'application/json',
             status: 404,
         };
-    }
+    },
 
-    formatDir(dirPath, entries) {
+    formatDir: (dirPath, entries) => {
         return {
             body: JSON.stringify(entries),
             type: 'application/json',
             status: 200,
         };
-    }
+    },
 
-    formatFile(path) {
-        return new Promise((resolve, reject) => {
-            fs.stat(path, (err, stats) => {
-                if (err) {
-                    return reject(err);
-                }
-                resolve({
-                    type: 'application/json',
-                    body: JSON.stringify(stats),
-                    status: 200,
-                });
-            });
-        });
-    }
-}
+    formatFile: ({ stats }) => {
+        return {
+            type: 'application/json',
+            body: JSON.stringify(stats),
+            status: 200,
+        };
+    },
+};

--- a/src/web-server/json-formatter.js
+++ b/src/web-server/json-formatter.js
@@ -1,0 +1,34 @@
+import fs from '../lib/fs';
+
+export default class {
+    format404(url) {
+        return {
+            body: `The requested URL ${url} was not found on this server.`,
+            type: 'application/json',
+            status: 404,
+        };
+    }
+
+    formatDir(dirPath, entries) {
+        return {
+            body: JSON.stringify(entries),
+            type: 'application/json',
+            status: 200,
+        };
+    }
+
+    formatFile(path) {
+        return new Promise((resolve, reject) => {
+            fs.stat(path, (err, stats) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve({
+                    type: 'application/json',
+                    body: JSON.stringify(stats),
+                    status: 200,
+                });
+            });
+        });
+    }
+}

--- a/src/web-server/routes.js
+++ b/src/web-server/routes.js
@@ -1,38 +1,9 @@
-import { format404, format404AsJson } from './html-formatter';
-import fs from '../lib/fs';
+import HtmlFormatter from './html-formatter';
+import JsonFormatter from './json-formatter';
 
 const wwwRegex = /\/www(\/.*)/;
-const wwwJsonRegex = /\/www\/json(\/.*)/;
-
-/**
- * Constructs a Response based on the success of the __func__ parameter.
- * This function assumes that return of the __func__ and __handle404__ will be an object containing __type__ and __body__.
- *
- * **E.g.**
- *
- * { type: 'html/text', body: '...'}
- * @param {*} param0 receives a __func__ reference to the main function to be called;
- *  __handle404__ function to be called in case error occured.
- */
-const constructResponse = async ({ func, handle404 }) => {
-    let res;
-    let status;
-    try {
-        res = await func();
-        status = 200;
-    } catch (err) {
-        res = handle404();
-        // TODO: should probably do a better job here on mapping to err
-        status = 404;
-    }
-
-    const config = {
-        status,
-        statusText: 'OK',
-        headers: { 'Content-Type': res.type },
-    };
-    return new Response(res.body, config);
-};
+const jsonFormatter = new JsonFormatter();
+const htmlFormatter = new HtmlFormatter();
 
 export default (workbox, webServer) => {
     // Cache service-worker icon files (PNG) in the root
@@ -41,56 +12,29 @@ export default (workbox, webServer) => {
         workbox.strategies.staleWhileRevalidate()
     );
 
-    workbox.routing.registerRoute(
-        wwwJsonRegex,
-        async ({ url }) => {
-            const path = url.pathname.match(wwwJsonRegex)[1];
-            // optionally check if we want to get file content,too
-            const getFileContent = !!url.searchParams.get('content');
-            return await constructResponse({
-                func: ((getContent, path) =>
-                    new Promise((resolve, reject) => {
-                        // run ls on the file
-                        fs.stat(path, (err, stats) => {
-                            if (err) {
-                                return reject(err);
-                            }
-                            if (getContent) {
-                                // get file content and append to response as `content` and `contentType`
-                                webServer.serve(path).then(res => {
-                                    resolve({
-                                        type: 'application/json',
-                                        body: JSON.stringify({
-                                            metadata: stats,
-                                            content: res.body,
-                                            contentType: res.type,
-                                        }),
-                                    });
-                                });
-                            } else {
-                                resolve({
-                                    type: 'application/json',
-                                    body: JSON.stringify({ metadata: stats }),
-                                });
-                            }
-                        });
-                    })).bind(null, getFileContent, path, webServer),
-                handle404: format404AsJson.bind(null, path),
-            });
-        },
-        'GET'
-    );
-
     // @ts-ignore
     workbox.routing.registerRoute(
         wwwRegex,
         async ({ url }) => {
+            const formatter =
+                url.searchParams.get('json') === 'true'
+                    ? jsonFormatter
+                    : htmlFormatter;
             const path = url.pathname.match(wwwRegex)[1];
 
-            return await constructResponse({
-                func: webServer.serve.bind(webServer, path),
-                handle404: format404.bind(null, path),
-            });
+            let res;
+            try {
+                res = await webServer.serve(path, formatter);
+            } catch (err) {
+                res = formatter.format404(path);
+            }
+
+            const config = {
+                status: res.status,
+                statusText: 'OK',
+                headers: { 'Content-Type': res.type },
+            };
+            return new Response(res.body, config);
         },
         'GET'
     );

--- a/src/web-server/routes.js
+++ b/src/web-server/routes.js
@@ -1,10 +1,7 @@
-import HtmlFormatter from './html-formatter';
-import JsonFormatter from './json-formatter';
+import htmlFormatter from './html-formatter';
+import jsonFormatter from './json-formatter';
 
 const wwwRegex = /\/www(\/.*)/;
-const jsonFormatter = new JsonFormatter();
-const htmlFormatter = new HtmlFormatter();
-
 export default (workbox, webServer) => {
     // Cache service-worker icon files (PNG) in the root
     workbox.routing.registerRoute(
@@ -28,7 +25,6 @@ export default (workbox, webServer) => {
             } catch (err) {
                 res = formatter.format404(path);
             }
-
             const config = {
                 status: res.status,
                 statusText: 'OK',

--- a/src/web-server/routes.js
+++ b/src/web-server/routes.js
@@ -1,6 +1,38 @@
-import { format404 } from './html-formatter';
+import { format404, format404AsJson } from './html-formatter';
+import fs from '../lib/fs';
 
 const wwwRegex = /\/www(\/.*)/;
+const wwwJsonRegex = /\/www\/json(\/.*)/;
+
+/**
+ * Constructs a Response based on the success of the __func__ parameter.
+ * This function assumes that return of the __func__ and __handle404__ will be an object containing __type__ and __body__.
+ *
+ * **E.g.**
+ *
+ * { type: 'html/text', body: '...'}
+ * @param {*} param0 receives a __func__ reference to the main function to be called;
+ *  __handle404__ function to be called in case error occured.
+ */
+const constructResponse = async ({ func, handle404 }) => {
+    let res;
+    let status;
+    try {
+        res = await func();
+        status = 200;
+    } catch (err) {
+        res = handle404();
+        // TODO: should probably do a better job here on mapping to err
+        status = 404;
+    }
+
+    const config = {
+        status,
+        statusText: 'OK',
+        headers: { 'Content-Type': res.type },
+    };
+    return new Response(res.body, config);
+};
 
 export default (workbox, webServer) => {
     // Cache service-worker icon files (PNG) in the root
@@ -9,33 +41,56 @@ export default (workbox, webServer) => {
         workbox.strategies.staleWhileRevalidate()
     );
 
+    workbox.routing.registerRoute(
+        wwwJsonRegex,
+        async ({ url }) => {
+            const path = url.pathname.match(wwwJsonRegex)[1];
+            // optionally check if we want to get file content,too
+            const getFileContent = !!url.searchParams.get('content');
+            return await constructResponse({
+                func: ((getContent, path) =>
+                    new Promise((resolve, reject) => {
+                        // run ls on the file
+                        fs.stat(path, (err, stats) => {
+                            if (err) {
+                                return reject(err);
+                            }
+                            if (getContent) {
+                                // get file content and append to response as `content` and `contentType`
+                                webServer.serve(path).then(res => {
+                                    resolve({
+                                        type: 'application/json',
+                                        body: JSON.stringify({
+                                            metadata: stats,
+                                            content: res.body,
+                                            contentType: res.type,
+                                        }),
+                                    });
+                                });
+                            } else {
+                                resolve({
+                                    type: 'application/json',
+                                    body: JSON.stringify({ metadata: stats }),
+                                });
+                            }
+                        });
+                    })).bind(null, getFileContent, path, webServer),
+                handle404: format404AsJson.bind(null, path),
+            });
+        },
+        'GET'
+    );
+
     // @ts-ignore
     workbox.routing.registerRoute(
         wwwRegex,
         async ({ url }) => {
             const path = url.pathname.match(wwwRegex)[1];
-            let body;
-            let type;
-            let status;
-            try {
-                const result = await webServer.serve(path);
-                body = result.body;
-                type = result.type;
-                status = 200;
-            } catch (err) {
-                body = format404(path);
-                type = 'text/html';
-                // TODO: should probably do a better job here on mapping to err
-                status = 404;
-            }
 
-            const init = {
-                status,
-                statusText: 'OK',
-                headers: { 'Content-Type': type },
-            };
-
-            return new Response(body, init);
+            return await constructResponse({
+                func: webServer.serve.bind(webServer, path),
+                handle404: format404.bind(null, path),
+            });
         },
         'GET'
     );


### PR DESCRIPTION
Modifying an endpoint that when called, is going to perform `stat` of the filesystem and return result.

 `www/path-to-file/file?json=true` - will return a json: 
```
{metadata}
```
* [metadata](https://github.com/filerjs/filer#stat)

 `www/folder-name?json=true` - will return a json: 
```
{[metadata]}
```
* [metadata](https://github.com/filerjs/filer#stat), where metadata is given for all first level entries inside the given folder

If file does not exist, `404` is returned.

Addressing #95 