### PR TITLE
Fix #109: register terminal routes with Service Worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
         "build-docs": "cd src/docs/website && npm run build",
         "build-editor": "cd src/editor && npm run build",
         "build-server": "parcel build src/index.html",
-        "build-vm": "node tools/download-vm.js",
-        "prebuild-terminal": "npm run build-vm",
+        "predownload-vm": "npm run build-server",
+        "download-vm": "node tools/download-vm.js",
+        "prebuild-terminal": "npm run download-vm",
         "build-terminal":
             "parcel build src/terminal/index.html --public-url /terminal --out-dir dist/terminal",
         "eslint": "eslint --fix .",

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -2,6 +2,7 @@ import DatabaseServer from './db';
 import WebServer from './web-server';
 import docs from './docs';
 import editor from './editor/src/routes.js';
+import terminal from './terminal';
 
 /* global workbox */
 importScripts(
@@ -27,3 +28,6 @@ webServer.init(workbox);
 // Create DatabaseServer and associated /data/* routes
 const dbServer = new DatabaseServer();
 dbServer.init(workbox);
+
+// Setup caching for terminal and vm binary resources
+terminal.init(workbox);


### PR DESCRIPTION
This adds back the service worker registration needed for the terminal code, it looks like it got lost in a rebase.

I've also added a build-step dependency for the server in the terminal build, since we need that for it to work.