### PR TITLE
Issue #105 - siteConfig.js fixed to work locally and gh-pages

### DIFF
--- a/src/docs/website/siteConfig.js
+++ b/src/docs/website/siteConfig.js
@@ -11,8 +11,8 @@
 const siteConfig = {
     title: 'Next',
     tagline: 'An experiment to unbunble the web',
-    url: 'https://humphd.github.io',
-    baseUrl: '/next/',
+    url: 'https://humphd.github.io/next',
+    baseUrl: '/',
     projectName: 'Next',
     organizationName: 'humphd',
 


### PR DESCRIPTION
The docs were not working initially because the `baseUrl` was set to `/next/`. I changed the `baseUrl` to `/` and moved `/next` to the end of the `url` instead. 