### PR TITLE
Fix #86: Run eslint when we run tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,8 @@ cache:
     # cache the bios, linux binary images
     - "dist/terminal/bin"
 
-before_script:
-  # Check if the current build is done against a PR.
-  # If yes, test whether all files(except json) conform with style guide defined by Prettier.
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ./node_modules/.bin/precise-commits --whitelist="./**/!(*.json)" --check-only --head=$TRAVIS_PULL_REQUEST_SHA --base=$(git merge-base HEAD $TRAVIS_BRANCH); fi'
+script:
+  - npm run travis
 
 before_deploy:
   # Do the entire build

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
             "parcel build src/terminal/index.html --public-url /terminal --out-dir dist/terminal",
         "eslint": "eslint --fix .",
         "check-eslint": "eslint .",
+        "travis": "npm run test",
         "v86:setup": "docker build -t buildroot .",
         "v86:bash": "cross-env OVERRIDE_CONFIG_DIR=1 node tools/build-v86 -ti --entrypoint \"bash\"",
         "v86:build": "node tools/build-v86"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "eslint": "eslint --fix .",
         "check-eslint": "eslint .",
         "travis": "npm run test",
+        "pretravis": "npm run check-eslint",
         "v86:setup": "docker build -t buildroot .",
         "v86:bash": "cross-env OVERRIDE_CONFIG_DIR=1 node tools/build-v86 -ti --entrypoint \"bash\"",
         "v86:build": "node tools/build-v86"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "build-terminal":
             "parcel build src/terminal/index.html --public-url /terminal --out-dir dist/terminal",
         "eslint": "eslint --fix .",
+        "check-eslint": "eslint .",
         "v86:setup": "docker build -t buildroot .",
         "v86:bash": "cross-env OVERRIDE_CONFIG_DIR=1 node tools/build-v86 -ti --entrypoint \"bash\"",
         "v86:build": "node tools/build-v86"


### PR DESCRIPTION
Fixes #86 - this PR executes `eslint` when we run tests, both locally and on Travis.