### PR TITLE
Fix Travis caching issue with git on npm install, switch to git SHA vs. branch names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,7 @@ sudo: false
 
 cache: 
   directories:
-    # cache the larger node_modules we use throughout the tree 
-    # - "node_modules"
-    # - "src/editor/node_modules"
-    # - "src/website/node_modules"
-    # cache the bios, linux binary images
-    - "dist/terminal/bin"
+    - $HOME/.npm
 
 script:
   - npm run travis
@@ -35,4 +30,3 @@ deploy:
   on:
     branch: master
     node: 'lts/*'
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
             "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
             }
         },
         "@zeit/schemas": {
@@ -53,7 +53,7 @@
             "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3"
+                "acorn": "^5.0.0"
             }
         },
         "acorn-jsx": {
@@ -62,7 +62,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "3.3.0"
+                "acorn": "^3.0.4"
             },
             "dependencies": {
                 "acorn": {
@@ -79,7 +79,7 @@
             "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
             "dev": true,
             "requires": {
-                "es6-promisify": "5.0.0"
+                "es6-promisify": "^5.0.0"
             }
         },
         "ajv": {
@@ -87,10 +87,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ajv-keywords": {
@@ -105,9 +105,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "alphanum-sort": {
@@ -148,7 +148,7 @@
             "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
             "dev": true,
             "requires": {
-                "color-convert": "1.9.1"
+                "color-convert": "^1.9.0"
             }
         },
         "ansi-wrap": {
@@ -163,8 +163,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "3.1.10",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -179,19 +179,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "normalize-path": {
@@ -200,7 +200,7 @@
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                     "dev": true,
                     "requires": {
-                        "remove-trailing-separator": "1.1.0"
+                        "remove-trailing-separator": "^1.0.1"
                     }
                 }
             }
@@ -211,7 +211,7 @@
             "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
             "dev": true,
             "requires": {
-                "default-require-extensions": "1.0.0"
+                "default-require-extensions": "^1.0.0"
             }
         },
         "archy": {
@@ -230,7 +230,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -278,7 +278,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -310,9 +310,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "assert": {
@@ -398,12 +398,12 @@
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000849",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "browserslist": "^1.7.6",
+                "caniuse-db": "^1.0.30000634",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^5.2.16",
+                "postcss-value-parser": "^3.2.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -418,8 +418,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000849",
-                        "electron-to-chromium": "1.3.48"
+                        "caniuse-db": "^1.0.30000639",
+                        "electron-to-chromium": "^1.2.7"
                     }
                 },
                 "chalk": {
@@ -428,11 +428,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -455,10 +455,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -467,7 +467,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -488,9 +488,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -505,11 +505,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -526,25 +526,25 @@
             "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.1",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.5.1",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
             }
         },
         "babel-generator": {
@@ -553,14 +553,14 @@
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.10",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
             }
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -569,9 +569,9 @@
             "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
             "dev": true,
             "requires": {
-                "babel-helper-explode-assignable-expression": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-explode-assignable-expression": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-builder-react-jsx": {
@@ -580,9 +580,9 @@
             "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "esutils": "2.0.2"
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "esutils": "^2.0.2"
             }
         },
         "babel-helper-call-delegate": {
@@ -591,10 +591,10 @@
             "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
             "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-define-map": {
@@ -603,10 +603,10 @@
             "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-helper-explode-assignable-expression": {
@@ -615,9 +615,9 @@
             "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-function-name": {
@@ -626,11 +626,11 @@
             "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
             "dev": true,
             "requires": {
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-get-function-arity": {
@@ -639,8 +639,8 @@
             "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-hoist-variables": {
@@ -649,8 +649,8 @@
             "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-optimise-call-expression": {
@@ -659,8 +659,8 @@
             "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-regex": {
@@ -669,9 +669,9 @@
             "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-helper-remap-async-to-generator": {
@@ -680,11 +680,11 @@
             "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-replace-supers": {
@@ -693,12 +693,12 @@
             "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
             "dev": true,
             "requires": {
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helpers": {
@@ -707,8 +707,8 @@
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-jest": {
@@ -717,8 +717,8 @@
             "integrity": "sha1-u6079SP7IC2gXtCmVAtIyE7tE6Y=",
             "dev": true,
             "requires": {
-                "babel-plugin-istanbul": "4.1.6",
-                "babel-preset-jest": "23.0.1"
+                "babel-plugin-istanbul": "^4.1.6",
+                "babel-preset-jest": "^23.0.1"
             }
         },
         "babel-messages": {
@@ -727,7 +727,7 @@
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-check-es2015-constants": {
@@ -736,7 +736,7 @@
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-istanbul": {
@@ -745,10 +745,10 @@
             "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-object-rest-spread": "6.13.0",
-                "find-up": "2.1.0",
-                "istanbul-lib-instrument": "1.10.1",
-                "test-exclude": "4.2.1"
+                "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+                "find-up": "^2.1.0",
+                "istanbul-lib-instrument": "^1.10.1",
+                "test-exclude": "^4.2.1"
             }
         },
         "babel-plugin-jest-hoist": {
@@ -793,9 +793,9 @@
             "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
             "dev": true,
             "requires": {
-                "babel-helper-remap-async-to-generator": "6.24.1",
-                "babel-plugin-syntax-async-functions": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-remap-async-to-generator": "^6.24.1",
+                "babel-plugin-syntax-async-functions": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -804,7 +804,7 @@
             "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -813,7 +813,7 @@
             "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -822,11 +822,11 @@
             "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -835,15 +835,15 @@
             "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
             "dev": true,
             "requires": {
-                "babel-helper-define-map": "6.26.0",
-                "babel-helper-function-name": "6.24.1",
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-define-map": "^6.24.1",
+                "babel-helper-function-name": "^6.24.1",
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -852,8 +852,8 @@
             "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -862,7 +862,7 @@
             "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -871,8 +871,8 @@
             "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -881,7 +881,7 @@
             "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -890,9 +890,9 @@
             "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -901,7 +901,7 @@
             "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -910,9 +910,9 @@
             "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -921,10 +921,10 @@
             "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-strict-mode": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-plugin-transform-strict-mode": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-types": "^6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -933,9 +933,9 @@
             "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
             "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -944,9 +944,9 @@
             "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -955,8 +955,8 @@
             "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
             "dev": true,
             "requires": {
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-runtime": "6.26.0"
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -965,12 +965,12 @@
             "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
             "dev": true,
             "requires": {
-                "babel-helper-call-delegate": "6.24.1",
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-call-delegate": "^6.24.1",
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -979,8 +979,8 @@
             "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -989,7 +989,7 @@
             "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -998,9 +998,9 @@
             "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
             "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -1009,7 +1009,7 @@
             "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1018,7 +1018,7 @@
             "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -1027,9 +1027,9 @@
             "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
             "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "regexpu-core": "2.0.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "regexpu-core": "^2.0.0"
             }
         },
         "babel-plugin-transform-exponentiation-operator": {
@@ -1038,9 +1038,9 @@
             "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
             "dev": true,
             "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-react-jsx": {
@@ -1049,9 +1049,9 @@
             "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
             "dev": true,
             "requires": {
-                "babel-helper-builder-react-jsx": "6.26.0",
-                "babel-plugin-syntax-jsx": "6.18.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-builder-react-jsx": "^6.24.1",
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-regenerator": {
@@ -1060,7 +1060,7 @@
             "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
             "dev": true,
             "requires": {
-                "regenerator-transform": "0.10.1"
+                "regenerator-transform": "^0.10.0"
             }
         },
         "babel-plugin-transform-runtime": {
@@ -1069,7 +1069,7 @@
             "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-strict-mode": {
@@ -1078,8 +1078,8 @@
             "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-preset-env": {
@@ -1088,36 +1088,36 @@
             "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
             "dev": true,
             "requires": {
-                "babel-plugin-check-es2015-constants": "6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-                "babel-plugin-transform-async-to-generator": "6.24.1",
-                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-                "babel-plugin-transform-es2015-classes": "6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-                "babel-plugin-transform-es2015-for-of": "6.23.0",
-                "babel-plugin-transform-es2015-function-name": "6.24.1",
-                "babel-plugin-transform-es2015-literals": "6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-                "babel-plugin-transform-es2015-object-super": "6.24.1",
-                "babel-plugin-transform-es2015-parameters": "6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-                "babel-plugin-transform-es2015-spread": "6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-exponentiation-operator": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0",
-                "browserslist": "3.2.8",
-                "invariant": "2.2.4",
-                "semver": "5.5.0"
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+                "babel-plugin-transform-async-to-generator": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+                "babel-plugin-transform-es2015-classes": "^6.23.0",
+                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+                "babel-plugin-transform-es2015-for-of": "^6.23.0",
+                "babel-plugin-transform-es2015-function-name": "^6.22.0",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+                "babel-plugin-transform-es2015-object-super": "^6.22.0",
+                "babel-plugin-transform-es2015-parameters": "^6.23.0",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+                "babel-plugin-transform-regenerator": "^6.22.0",
+                "browserslist": "^3.2.6",
+                "invariant": "^2.2.2",
+                "semver": "^5.3.0"
             }
         },
         "babel-preset-jest": {
@@ -1126,8 +1126,8 @@
             "integrity": "sha1-YxzFRcbPAhlDATvK8i9F2H/mIZg=",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "23.0.1",
-                "babel-plugin-syntax-object-rest-spread": "6.13.0"
+                "babel-plugin-jest-hoist": "^23.0.1",
+                "babel-plugin-syntax-object-rest-spread": "^6.13.0"
             }
         },
         "babel-register": {
@@ -1136,13 +1136,13 @@
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
-                "babel-core": "6.26.3",
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.7",
-                "home-or-tmp": "2.0.0",
-                "lodash": "4.17.10",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18"
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
             }
         },
         "babel-runtime": {
@@ -1151,8 +1151,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             }
         },
         "babel-template": {
@@ -1161,11 +1161,11 @@
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-traverse": {
@@ -1174,15 +1174,15 @@
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.4",
-                "lodash": "4.17.10"
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
             }
         },
         "babel-types": {
@@ -1191,10 +1191,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.10",
-                "to-fast-properties": "1.0.3"
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
             }
         },
         "babylon": {
@@ -1209,9 +1209,9 @@
             "integrity": "sha1-OxWl3btIKni0zpwByLoYFwLZ1s4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash.clone": "4.5.0"
+                "babel-runtime": "^6.11.6",
+                "babel-types": "^6.15.0",
+                "lodash.clone": "^4.5.0"
             }
         },
         "balanced-match": {
@@ -1225,13 +1225,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1240,7 +1240,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1249,7 +1249,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -1258,7 +1258,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -1267,9 +1267,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "kind-of": {
@@ -1297,7 +1297,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "binary": {
@@ -1305,8 +1305,8 @@
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
             "requires": {
-                "buffers": "0.1.1",
-                "chainsaw": "0.1.0"
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
             }
         },
         "binary-extensions": {
@@ -1326,7 +1326,7 @@
             "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
             "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
             "requires": {
-                "readable-stream": "1.0.34"
+                "readable-stream": "~1.0.26"
             },
             "dependencies": {
                 "isarray": {
@@ -1339,10 +1339,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1375,7 +1375,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
             "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
             "requires": {
-                "hoek": "0.9.1"
+                "hoek": "0.9.x"
             }
         },
         "bower": {
@@ -1383,47 +1383,47 @@
             "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.12.tgz",
             "integrity": "sha1-N94O2zkEuvkK7hM4Sho3mgXuIUw=",
             "requires": {
-                "abbrev": "1.0.9",
+                "abbrev": "~1.0.4",
                 "archy": "0.0.2",
-                "bower-config": "0.5.3",
-                "bower-endpoint-parser": "0.2.2",
-                "bower-json": "0.4.0",
-                "bower-logger": "0.2.2",
-                "bower-registry-client": "0.2.4",
+                "bower-config": "~0.5.2",
+                "bower-endpoint-parser": "~0.2.2",
+                "bower-json": "~0.4.0",
+                "bower-logger": "~0.2.2",
+                "bower-registry-client": "~0.2.0",
                 "cardinal": "0.4.0",
                 "chalk": "0.5.0",
                 "chmodr": "0.1.0",
                 "decompress-zip": "0.0.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "glob": "4.0.6",
-                "graceful-fs": "3.0.11",
-                "handlebars": "2.0.0",
+                "fstream": "~1.0.2",
+                "fstream-ignore": "~1.0.1",
+                "glob": "~4.0.2",
+                "graceful-fs": "~3.0.1",
+                "handlebars": "~2.0.0",
                 "inquirer": "0.7.1",
                 "insight": "0.4.3",
-                "is-root": "1.0.0",
-                "junk": "1.0.3",
-                "lockfile": "1.0.4",
-                "lru-cache": "2.5.2",
+                "is-root": "~1.0.0",
+                "junk": "~1.0.0",
+                "lockfile": "~1.0.0",
+                "lru-cache": "~2.5.0",
                 "mkdirp": "0.5.0",
-                "mout": "0.9.1",
-                "nopt": "3.0.6",
-                "opn": "1.0.2",
+                "mout": "~0.9.0",
+                "nopt": "~3.0.0",
+                "opn": "~1.0.0",
                 "osenv": "0.1.0",
                 "p-throttler": "0.1.0",
                 "promptly": "0.2.0",
-                "q": "1.0.1",
-                "request": "2.42.0",
+                "q": "~1.0.1",
+                "request": "~2.42.0",
                 "request-progress": "0.3.0",
                 "retry": "0.6.0",
-                "rimraf": "2.2.8",
-                "semver": "2.3.2",
-                "shell-quote": "1.4.3",
-                "stringify-object": "1.0.1",
+                "rimraf": "~2.2.0",
+                "semver": "~2.3.0",
+                "shell-quote": "~1.4.1",
+                "stringify-object": "~1.0.0",
                 "tar-fs": "0.5.2",
                 "tmp": "0.0.23",
                 "update-notifier": "0.2.0",
-                "which": "1.0.9"
+                "which": "~1.0.5"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1470,11 +1470,11 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.0.tgz",
                     "integrity": "sha1-N138y8IcCmCothvFt489wqVcIS8=",
                     "requires": {
-                        "ansi-styles": "1.1.0",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "0.1.0",
-                        "strip-ansi": "0.3.0",
-                        "supports-color": "0.2.0"
+                        "ansi-styles": "^1.1.0",
+                        "escape-string-regexp": "^1.0.0",
+                        "has-ansi": "^0.1.0",
+                        "strip-ansi": "^0.3.0",
+                        "supports-color": "^0.2.0"
                     }
                 },
                 "combined-stream": {
@@ -1503,9 +1503,9 @@
                     "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
                     "optional": true,
                     "requires": {
-                        "async": "0.9.2",
-                        "combined-stream": "0.0.7",
-                        "mime": "1.2.11"
+                        "async": "~0.9.0",
+                        "combined-stream": "~0.0.4",
+                        "mime": "~1.2.11"
                     }
                 },
                 "glob": {
@@ -1513,10 +1513,10 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
                     "integrity": "sha1-aVxQvdTi+1xdNwsJHziNNwfikac=",
                     "requires": {
-                        "graceful-fs": "3.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "1.0.0",
-                        "once": "1.4.0"
+                        "graceful-fs": "^3.0.2",
+                        "inherits": "2",
+                        "minimatch": "^1.0.0",
+                        "once": "^1.3.0"
                     }
                 },
                 "graceful-fs": {
@@ -1524,7 +1524,7 @@
                     "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "requires": {
-                        "natives": "1.1.4"
+                        "natives": "^1.1.0"
                     }
                 },
                 "has-ansi": {
@@ -1532,7 +1532,7 @@
                     "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                     "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.0"
                     }
                 },
                 "http-signature": {
@@ -1542,7 +1542,7 @@
                     "optional": true,
                     "requires": {
                         "asn1": "0.1.11",
-                        "assert-plus": "0.1.5",
+                        "assert-plus": "^0.1.5",
                         "ctype": "0.5.3"
                     }
                 },
@@ -1551,14 +1551,14 @@
                     "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.7.1.tgz",
                     "integrity": "sha1-uKzxQBZb1YGGLtEZj7bSZDAJH6w=",
                     "requires": {
-                        "chalk": "0.5.0",
-                        "cli-color": "0.3.3",
-                        "figures": "1.7.0",
-                        "lodash": "2.4.2",
+                        "chalk": "^0.5.0",
+                        "cli-color": "~0.3.2",
+                        "figures": "^1.3.2",
+                        "lodash": "~2.4.1",
                         "mute-stream": "0.0.4",
-                        "readline2": "0.1.1",
-                        "rx": "2.5.3",
-                        "through": "2.3.8"
+                        "readline2": "~0.1.0",
+                        "rx": "^2.2.27",
+                        "through": "~2.3.4"
                     }
                 },
                 "lodash": {
@@ -1587,8 +1587,8 @@
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                     "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
                     "requires": {
-                        "lru-cache": "2.5.2",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 },
                 "mkdirp": {
@@ -1625,21 +1625,21 @@
                     "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
                     "integrity": "sha1-VyvQFIk4VkBArHqxSLlkI6BjMEo=",
                     "requires": {
-                        "aws-sign2": "0.5.0",
-                        "bl": "0.9.5",
-                        "caseless": "0.6.0",
-                        "forever-agent": "0.5.2",
-                        "form-data": "0.1.4",
+                        "aws-sign2": "~0.5.0",
+                        "bl": "~0.9.0",
+                        "caseless": "~0.6.0",
+                        "forever-agent": "~0.5.0",
+                        "form-data": "~0.1.0",
                         "hawk": "1.1.1",
-                        "http-signature": "0.10.1",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "1.0.2",
-                        "node-uuid": "1.4.8",
-                        "oauth-sign": "0.4.0",
-                        "qs": "1.2.2",
-                        "stringstream": "0.0.6",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3"
+                        "http-signature": "~0.10.0",
+                        "json-stringify-safe": "~5.0.0",
+                        "mime-types": "~1.0.1",
+                        "node-uuid": "~1.4.0",
+                        "oauth-sign": "~0.4.0",
+                        "qs": "~1.2.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": ">=0.12.0",
+                        "tunnel-agent": "~0.4.0"
                     }
                 },
                 "rimraf": {
@@ -1657,7 +1657,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                     "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.1"
                     }
                 },
                 "supports-color": {
@@ -1687,9 +1687,9 @@
             "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.3.tgz",
             "integrity": "sha1-mPxbQah4cO+cu5KXY1z4H1UF/bE=",
             "requires": {
-                "graceful-fs": "2.0.3",
-                "mout": "0.9.1",
-                "optimist": "0.6.1",
+                "graceful-fs": "~2.0.0",
+                "mout": "~0.9.0",
+                "optimist": "~0.6.0",
                 "osenv": "0.0.3"
             },
             "dependencies": {
@@ -1715,9 +1715,9 @@
             "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
             "integrity": "sha1-qZw8z0Fu8FkO0N7SUsdg8cbZN2Y=",
             "requires": {
-                "deep-extend": "0.2.11",
-                "graceful-fs": "2.0.3",
-                "intersect": "0.0.3"
+                "deep-extend": "~0.2.5",
+                "graceful-fs": "~2.0.0",
+                "intersect": "~0.0.3"
             },
             "dependencies": {
                 "graceful-fs": {
@@ -1737,14 +1737,14 @@
             "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
             "integrity": "sha1-Jp/H6Ji2J/uTnRFEpZMlTX+77rw=",
             "requires": {
-                "async": "0.2.10",
-                "bower-config": "0.5.3",
-                "graceful-fs": "2.0.3",
-                "lru-cache": "2.3.1",
-                "mkdirp": "0.3.5",
-                "request": "2.51.0",
-                "request-replay": "0.2.0",
-                "rimraf": "2.2.8"
+                "async": "~0.2.8",
+                "bower-config": "~0.5.0",
+                "graceful-fs": "~2.0.0",
+                "lru-cache": "~2.3.0",
+                "mkdirp": "~0.3.5",
+                "request": "~2.51.0",
+                "request-replay": "~0.2.0",
+                "rimraf": "~2.2.0"
             },
             "dependencies": {
                 "asn1": {
@@ -1790,9 +1790,9 @@
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                     "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
                     "requires": {
-                        "async": "0.9.2",
-                        "combined-stream": "0.0.7",
-                        "mime-types": "2.0.14"
+                        "async": "~0.9.0",
+                        "combined-stream": "~0.0.4",
+                        "mime-types": "~2.0.3"
                     },
                     "dependencies": {
                         "async": {
@@ -1805,7 +1805,7 @@
                             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                             "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
                             "requires": {
-                                "mime-db": "1.12.0"
+                                "mime-db": "~1.12.0"
                             }
                         }
                     }
@@ -1821,7 +1821,7 @@
                     "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
                     "requires": {
                         "asn1": "0.1.11",
-                        "assert-plus": "0.1.5",
+                        "assert-plus": "^0.1.5",
                         "ctype": "0.5.3"
                     }
                 },
@@ -1865,22 +1865,22 @@
                     "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                     "integrity": "sha1-NdALvswBLlX5B7G9ng29V3v+8m4=",
                     "requires": {
-                        "aws-sign2": "0.5.0",
-                        "bl": "0.9.5",
-                        "caseless": "0.8.0",
-                        "combined-stream": "0.0.7",
-                        "forever-agent": "0.5.2",
-                        "form-data": "0.2.0",
+                        "aws-sign2": "~0.5.0",
+                        "bl": "~0.9.0",
+                        "caseless": "~0.8.0",
+                        "combined-stream": "~0.0.5",
+                        "forever-agent": "~0.5.0",
+                        "form-data": "~0.2.0",
                         "hawk": "1.1.1",
-                        "http-signature": "0.10.1",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "1.0.2",
-                        "node-uuid": "1.4.8",
-                        "oauth-sign": "0.5.0",
-                        "qs": "2.3.3",
-                        "stringstream": "0.0.6",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3"
+                        "http-signature": "~0.10.0",
+                        "json-stringify-safe": "~5.0.0",
+                        "mime-types": "~1.0.1",
+                        "node-uuid": "~1.4.0",
+                        "oauth-sign": "~0.5.0",
+                        "qs": "~2.3.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": ">=0.12.0",
+                        "tunnel-agent": "~0.4.0"
                     }
                 },
                 "rimraf": {
@@ -1900,7 +1900,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -1910,16 +1910,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1928,7 +1928,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1939,10 +1939,10 @@
             "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
             "dev": true,
             "requires": {
-                "quote-stream": "1.0.2",
-                "resolve": "1.1.7",
-                "static-module": "2.2.5",
-                "through2": "2.0.3"
+                "quote-stream": "^1.0.1",
+                "resolve": "^1.1.5",
+                "static-module": "^2.2.0",
+                "through2": "^2.0.0"
             }
         },
         "brorand": {
@@ -1972,12 +1972,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "browserify-cipher": {
@@ -1986,9 +1986,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.2.0",
-                "browserify-des": "1.0.1",
-                "evp_bytestokey": "1.0.3"
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
             }
         },
         "browserify-des": {
@@ -1997,9 +1997,9 @@
             "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.0",
-                "inherits": "2.0.3"
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "browserify-rsa": {
@@ -2008,8 +2008,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
             }
         },
         "browserify-sign": {
@@ -2018,13 +2018,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "elliptic": "6.4.0",
-                "inherits": "2.0.3",
-                "parse-asn1": "5.1.1"
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
             }
         },
         "browserify-zlib": {
@@ -2033,7 +2033,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "1.0.6"
+                "pako": "~1.0.5"
             },
             "dependencies": {
                 "pako": {
@@ -2050,8 +2050,8 @@
             "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "1.0.30000849",
-                "electron-to-chromium": "1.3.48"
+                "caniuse-lite": "^1.0.30000844",
+                "electron-to-chromium": "^1.3.47"
             }
         },
         "bser": {
@@ -2060,7 +2060,7 @@
             "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
             "dev": true,
             "requires": {
-                "node-int64": "0.4.0"
+                "node-int64": "^0.4.0"
             }
         },
         "buffer": {
@@ -2069,9 +2069,9 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "1.3.0",
-                "ieee754": "1.1.11",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             }
         },
         "buffer-equal": {
@@ -2121,15 +2121,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "caller-path": {
@@ -2138,7 +2138,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsites": {
@@ -2160,10 +2160,10 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000849",
-                "lodash.memoize": "4.1.2",
-                "lodash.uniq": "4.5.0"
+                "browserslist": "^1.3.6",
+                "caniuse-db": "^1.0.30000529",
+                "lodash.memoize": "^4.1.2",
+                "lodash.uniq": "^4.5.0"
             },
             "dependencies": {
                 "browserslist": {
@@ -2172,8 +2172,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000849",
-                        "electron-to-chromium": "1.3.48"
+                        "caniuse-db": "^1.0.30000639",
+                        "electron-to-chromium": "^1.2.7"
                     }
                 }
             }
@@ -2196,7 +2196,7 @@
             "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
             "dev": true,
             "requires": {
-                "rsvp": "3.6.2"
+                "rsvp": "^3.3.3"
             }
         },
         "cardinal": {
@@ -2204,7 +2204,7 @@
             "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.0.tgz",
             "integrity": "sha1-fRCq+yCDe94EPEXkOgyMKM2q5F4=",
             "requires": {
-                "redeyed": "0.4.4"
+                "redeyed": "~0.4.0"
             }
         },
         "caseless": {
@@ -2219,8 +2219,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chainsaw": {
@@ -2228,7 +2228,7 @@
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
             "requires": {
-                "traverse": "0.3.9"
+                "traverse": ">=0.3.0 <0.4"
             }
         },
         "chalk": {
@@ -2237,9 +2237,9 @@
             "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "chardet": {
@@ -2259,18 +2259,18 @@
             "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.2",
-                "fsevents": "1.2.4",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0",
-                "upath": "1.1.0"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.1.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -2279,8 +2279,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -2289,7 +2289,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -2306,7 +2306,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "normalize-path": {
@@ -2315,7 +2315,7 @@
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                     "dev": true,
                     "requires": {
-                        "remove-trailing-separator": "1.1.0"
+                        "remove-trailing-separator": "^1.0.1"
                     }
                 }
             }
@@ -2332,8 +2332,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "circular-json": {
@@ -2348,7 +2348,7 @@
             "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3"
+                "chalk": "^1.1.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -2363,11 +2363,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -2384,10 +2384,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2396,7 +2396,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -2406,10 +2406,10 @@
             "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
             "integrity": "sha1-EtW90Vj/igsNtAEZiRPAPfBp9vU=",
             "requires": {
-                "d": "0.1.1",
-                "es5-ext": "0.10.45",
-                "memoizee": "0.3.10",
-                "timers-ext": "0.1.5"
+                "d": "~0.1.1",
+                "es5-ext": "~0.10.6",
+                "memoizee": "~0.3.8",
+                "timers-ext": "0.1"
             }
         },
         "cli-cursor": {
@@ -2418,7 +2418,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-spinners": {
@@ -2440,8 +2440,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             }
         },
@@ -2474,7 +2474,7 @@
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.1.2"
             },
             "dependencies": {
                 "q": {
@@ -2497,8 +2497,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color": {
@@ -2507,9 +2507,9 @@
             "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
-                "color-convert": "1.9.1",
-                "color-string": "0.3.0"
+                "clone": "^1.0.2",
+                "color-convert": "^1.3.0",
+                "color-string": "^0.3.0"
             }
         },
         "color-convert": {
@@ -2518,7 +2518,7 @@
             "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -2533,7 +2533,7 @@
             "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.0.0"
             }
         },
         "colormin": {
@@ -2542,9 +2542,9 @@
             "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
             "dev": true,
             "requires": {
-                "color": "0.11.4",
+                "color": "^0.11.0",
                 "css-color-names": "0.0.4",
-                "has": "1.0.1"
+                "has": "^1.0.1"
             }
         },
         "colors": {
@@ -2558,7 +2558,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "command-exists": {
@@ -2596,10 +2596,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "config-chain": {
@@ -2607,8 +2607,8 @@
             "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
             "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
             "requires": {
-                "ini": "1.3.5",
-                "proto-list": "1.2.4"
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
             }
         },
         "configstore": {
@@ -2616,14 +2616,14 @@
             "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
             "integrity": "sha1-JeTBbDdoq/dcWmW8YXYfSVBVtFk=",
             "requires": {
-                "graceful-fs": "3.0.11",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "object-assign": "2.1.1",
-                "osenv": "0.1.0",
-                "user-home": "1.1.1",
-                "uuid": "2.0.3",
-                "xdg-basedir": "1.0.1"
+                "graceful-fs": "^3.0.1",
+                "js-yaml": "^3.1.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^2.0.0",
+                "osenv": "^0.1.0",
+                "user-home": "^1.0.0",
+                "uuid": "^2.0.1",
+                "xdg-basedir": "^1.0.0"
             },
             "dependencies": {
                 "graceful-fs": {
@@ -2631,7 +2631,7 @@
                     "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "requires": {
-                        "natives": "1.1.4"
+                        "natives": "^1.1.0"
                     }
                 },
                 "object-assign": {
@@ -2652,7 +2652,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "0.1.4"
+                "date-now": "^0.1.4"
             }
         },
         "constants-browserify": {
@@ -2679,20 +2679,20 @@
             "integrity": "sha512-drDFuUZctIuvSuvL9dOF/v5GxrwB1Q8eMIRlYONC0lSMEq+L2xabXP3jme8cQFdDO8cgP8JsuYhQg7JtTwezmg==",
             "dev": true,
             "requires": {
-                "async-each": "1.0.1",
-                "bluebird": "3.5.1",
-                "extend-shallow": "2.0.1",
-                "file-contents": "0.3.2",
-                "glob-parent": "2.0.0",
-                "graceful-fs": "4.1.11",
-                "has-glob": "0.1.1",
-                "is-absolute": "0.2.6",
-                "lazy-cache": "2.0.2",
-                "log-ok": "0.1.1",
-                "matched": "0.4.4",
-                "mkdirp": "0.5.1",
-                "resolve-dir": "0.1.1",
-                "to-file": "0.2.0"
+                "async-each": "^1.0.0",
+                "bluebird": "^3.4.1",
+                "extend-shallow": "^2.0.1",
+                "file-contents": "^0.3.1",
+                "glob-parent": "^2.0.0",
+                "graceful-fs": "^4.1.4",
+                "has-glob": "^0.1.1",
+                "is-absolute": "^0.2.5",
+                "lazy-cache": "^2.0.1",
+                "log-ok": "^0.1.1",
+                "matched": "^0.4.1",
+                "mkdirp": "^0.5.1",
+                "resolve-dir": "^0.1.0",
+                "to-file": "^0.2.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2701,7 +2701,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "lazy-cache": {
@@ -2710,7 +2710,7 @@
                     "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
                     "dev": true,
                     "requires": {
-                        "set-getter": "0.1.0"
+                        "set-getter": "^0.1.0"
                     }
                 }
             }
@@ -2738,8 +2738,8 @@
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.0"
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
             }
         },
         "create-hash": {
@@ -2748,11 +2748,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "md5.js": "1.3.4",
-                "ripemd160": "2.0.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
             }
         },
         "create-hmac": {
@@ -2761,12 +2761,12 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "cross-env": {
@@ -2775,8 +2775,8 @@
             "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
             "dev": true,
             "requires": {
-                "cross-spawn": "6.0.5",
-                "is-windows": "1.0.2"
+                "cross-spawn": "^6.0.5",
+                "is-windows": "^1.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -2785,11 +2785,11 @@
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.4",
-                        "path-key": "2.0.1",
-                        "semver": "5.5.0",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.0"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 }
             }
@@ -2800,9 +2800,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.3",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "cryptiles": {
@@ -2810,7 +2810,7 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
             "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
             "requires": {
-                "boom": "0.4.2"
+                "boom": "0.4.x"
             }
         },
         "crypto-browserify": {
@@ -2819,17 +2819,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "1.0.1",
-                "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.3",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "diffie-hellman": "5.0.3",
-                "inherits": "2.0.3",
-                "pbkdf2": "3.0.16",
-                "public-encrypt": "4.0.2",
-                "randombytes": "2.0.6",
-                "randomfill": "1.0.4"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             }
         },
         "css-color-names": {
@@ -2844,10 +2844,10 @@
             "integrity": "sha1-b5MZaqrnN2ZuoQNqjLFKj8t6kjE=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "^1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "^1.0.1"
             },
             "dependencies": {
                 "domutils": {
@@ -2856,8 +2856,8 @@
                     "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
                     "dev": true,
                     "requires": {
-                        "dom-serializer": "0.1.0",
-                        "domelementtype": "1.3.0"
+                        "dom-serializer": "0",
+                        "domelementtype": "1"
                     }
                 }
             }
@@ -2874,8 +2874,8 @@
             "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
             "dev": true,
             "requires": {
-                "mdn-data": "1.1.4",
-                "source-map": "0.5.7"
+                "mdn-data": "^1.0.0",
+                "source-map": "^0.5.3"
             }
         },
         "css-url-regex": {
@@ -2896,38 +2896,38 @@
             "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
             "dev": true,
             "requires": {
-                "autoprefixer": "6.7.7",
-                "decamelize": "1.2.0",
-                "defined": "1.0.0",
-                "has": "1.0.1",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-calc": "5.3.1",
-                "postcss-colormin": "2.2.2",
-                "postcss-convert-values": "2.6.1",
-                "postcss-discard-comments": "2.0.4",
-                "postcss-discard-duplicates": "2.1.0",
-                "postcss-discard-empty": "2.1.0",
-                "postcss-discard-overridden": "0.1.1",
-                "postcss-discard-unused": "2.2.3",
-                "postcss-filter-plugins": "2.0.3",
-                "postcss-merge-idents": "2.1.7",
-                "postcss-merge-longhand": "2.0.2",
-                "postcss-merge-rules": "2.1.2",
-                "postcss-minify-font-values": "1.0.5",
-                "postcss-minify-gradients": "1.0.5",
-                "postcss-minify-params": "1.2.2",
-                "postcss-minify-selectors": "2.1.1",
-                "postcss-normalize-charset": "1.1.1",
-                "postcss-normalize-url": "3.0.8",
-                "postcss-ordered-values": "2.2.3",
-                "postcss-reduce-idents": "2.4.0",
-                "postcss-reduce-initial": "1.0.1",
-                "postcss-reduce-transforms": "1.0.4",
-                "postcss-svgo": "2.1.6",
-                "postcss-unique-selectors": "2.0.2",
-                "postcss-value-parser": "3.3.0",
-                "postcss-zindex": "2.2.0"
+                "autoprefixer": "^6.3.1",
+                "decamelize": "^1.1.2",
+                "defined": "^1.0.0",
+                "has": "^1.0.1",
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.14",
+                "postcss-calc": "^5.2.0",
+                "postcss-colormin": "^2.1.8",
+                "postcss-convert-values": "^2.3.4",
+                "postcss-discard-comments": "^2.0.4",
+                "postcss-discard-duplicates": "^2.0.1",
+                "postcss-discard-empty": "^2.0.1",
+                "postcss-discard-overridden": "^0.1.1",
+                "postcss-discard-unused": "^2.2.1",
+                "postcss-filter-plugins": "^2.0.0",
+                "postcss-merge-idents": "^2.1.5",
+                "postcss-merge-longhand": "^2.0.1",
+                "postcss-merge-rules": "^2.0.3",
+                "postcss-minify-font-values": "^1.0.2",
+                "postcss-minify-gradients": "^1.0.1",
+                "postcss-minify-params": "^1.0.4",
+                "postcss-minify-selectors": "^2.0.4",
+                "postcss-normalize-charset": "^1.1.0",
+                "postcss-normalize-url": "^3.0.7",
+                "postcss-ordered-values": "^2.1.0",
+                "postcss-reduce-idents": "^2.2.2",
+                "postcss-reduce-initial": "^1.0.0",
+                "postcss-reduce-transforms": "^1.0.3",
+                "postcss-svgo": "^2.1.1",
+                "postcss-unique-selectors": "^2.0.2",
+                "postcss-value-parser": "^3.2.3",
+                "postcss-zindex": "^2.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -2942,11 +2942,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -2969,10 +2969,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -2981,7 +2981,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -2992,8 +2992,8 @@
             "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
             "dev": true,
             "requires": {
-                "clap": "1.2.3",
-                "source-map": "0.5.7"
+                "clap": "^1.0.9",
+                "source-map": "^0.5.3"
             }
         },
         "cssom": {
@@ -3008,7 +3008,7 @@
             "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.2"
+                "cssom": "0.3.x"
             }
         },
         "ctype": {
@@ -3022,8 +3022,8 @@
             "integrity": "sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=",
             "dev": true,
             "requires": {
-                "find-pkg": "0.1.2",
-                "fs-exists-sync": "0.1.0"
+                "find-pkg": "^0.1.2",
+                "fs-exists-sync": "^0.1.0"
             }
         },
         "d": {
@@ -3031,7 +3031,7 @@
             "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
             "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
             "requires": {
-                "es5-ext": "0.10.45"
+                "es5-ext": "~0.10.2"
             }
         },
         "dashdash": {
@@ -3039,7 +3039,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "data-urls": {
@@ -3048,9 +3048,9 @@
             "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
             "dev": true,
             "requires": {
-                "abab": "1.0.4",
-                "whatwg-mimetype": "2.1.0",
-                "whatwg-url": "6.4.1"
+                "abab": "^1.0.4",
+                "whatwg-mimetype": "^2.0.0",
+                "whatwg-url": "^6.4.0"
             }
         },
         "date-now": {
@@ -3065,8 +3065,8 @@
             "integrity": "sha512-/6ngYM7AapueqLtvOzjv9+11N2fHDSrkxeMF1YPE20WIfaaawiBg+HZH1E5lHrcJxlKR42t6XPOEmMmqcAsU1g==",
             "dev": true,
             "requires": {
-                "bindings": "1.2.1",
-                "nan": "2.10.0"
+                "bindings": "~1.2.1",
+                "nan": "^2.0.7"
             }
         },
         "debug": {
@@ -3095,12 +3095,12 @@
             "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
             "integrity": "sha1-SiZbIseyCdeyT6ZvKy37ztWQRPM=",
             "requires": {
-                "binary": "0.3.0",
-                "graceful-fs": "3.0.11",
-                "mkpath": "0.1.0",
-                "nopt": "2.2.1",
-                "q": "1.0.1",
-                "readable-stream": "1.1.14",
+                "binary": "~0.3.0",
+                "graceful-fs": "~3.0.0",
+                "mkpath": "~0.1.0",
+                "nopt": "~2.2.0",
+                "q": "~1.0.0",
+                "readable-stream": "~1.1.8",
                 "touch": "0.0.2"
             },
             "dependencies": {
@@ -3109,7 +3109,7 @@
                     "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "requires": {
-                        "natives": "1.1.4"
+                        "natives": "^1.1.0"
                     }
                 },
                 "isarray": {
@@ -3122,7 +3122,7 @@
                     "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
                     "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
                     "requires": {
-                        "abbrev": "1.0.9"
+                        "abbrev": "1"
                     }
                 },
                 "readable-stream": {
@@ -3130,10 +3130,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -3154,7 +3154,7 @@
             "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
             "dev": true,
             "requires": {
-                "strip-bom": "2.0.0"
+                "strip-bom": "^2.0.0"
             }
         },
         "define-properties": {
@@ -3163,8 +3163,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "define-property": {
@@ -3173,8 +3173,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -3183,7 +3183,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -3192,7 +3192,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -3201,9 +3201,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "kind-of": {
@@ -3226,13 +3226,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "globby": {
@@ -3241,12 +3241,12 @@
                     "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "arrify": "1.0.1",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "arrify": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 }
             }
@@ -3268,8 +3268,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "destroy": {
@@ -3284,7 +3284,7 @@
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "detect-newline": {
@@ -3316,9 +3316,9 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
             }
         },
         "doctrine": {
@@ -3327,7 +3327,7 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2"
+                "esutils": "^2.0.2"
             }
         },
         "dom-serializer": {
@@ -3336,8 +3336,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -3366,7 +3366,7 @@
             "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
             "dev": true,
             "requires": {
-                "webidl-conversions": "4.0.2"
+                "webidl-conversions": "^4.0.2"
             }
         },
         "domhandler": {
@@ -3375,7 +3375,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -3384,8 +3384,8 @@
             "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "dotenv": {
@@ -3406,7 +3406,7 @@
             "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "ecc-jsbn": {
@@ -3415,7 +3415,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "editorconfig": {
@@ -3424,11 +3424,11 @@
             "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "commander": "2.15.1",
-                "lru-cache": "3.2.0",
-                "semver": "5.5.0",
-                "sigmund": "1.0.1"
+                "bluebird": "^3.0.5",
+                "commander": "^2.9.0",
+                "lru-cache": "^3.2.0",
+                "semver": "^5.1.0",
+                "sigmund": "^1.0.1"
             },
             "dependencies": {
                 "lru-cache": {
@@ -3437,7 +3437,7 @@
                     "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2"
+                        "pseudomap": "^1.0.1"
                     }
                 }
             }
@@ -3460,13 +3460,13 @@
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.3",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             }
         },
         "encodeurl": {
@@ -3480,7 +3480,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
             "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
             "requires": {
-                "once": "1.3.3"
+                "once": "~1.3.0"
             },
             "dependencies": {
                 "once": {
@@ -3488,7 +3488,7 @@
                     "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 }
             }
@@ -3505,7 +3505,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -3514,11 +3514,11 @@
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "1.1.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.1",
-                "is-callable": "1.1.3",
-                "is-regex": "1.0.4"
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
             }
         },
         "es-to-primitive": {
@@ -3527,9 +3527,9 @@
             "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
             "dev": true,
             "requires": {
-                "is-callable": "1.1.3",
-                "is-date-object": "1.0.1",
-                "is-symbol": "1.0.1"
+                "is-callable": "^1.1.1",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.1"
             }
         },
         "es5-ext": {
@@ -3537,9 +3537,9 @@
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
             "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1",
-                "next-tick": "1.0.0"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "1"
             }
         },
         "es6-iterator": {
@@ -3547,9 +3547,9 @@
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.45",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
             },
             "dependencies": {
                 "d": {
@@ -3557,7 +3557,7 @@
                     "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
                     "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
                     "requires": {
-                        "es5-ext": "0.10.45"
+                        "es5-ext": "^0.10.9"
                     }
                 }
             }
@@ -3574,7 +3574,7 @@
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "dev": true,
             "requires": {
-                "es6-promise": "4.2.4"
+                "es6-promise": "^4.0.3"
             }
         },
         "es6-symbol": {
@@ -3582,8 +3582,8 @@
             "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.45"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             },
             "dependencies": {
                 "d": {
@@ -3591,7 +3591,7 @@
                     "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
                     "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
                     "requires": {
-                        "es5-ext": "0.10.45"
+                        "es5-ext": "^0.10.9"
                     }
                 }
             }
@@ -3601,10 +3601,10 @@
             "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
             "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
             "requires": {
-                "d": "0.1.1",
-                "es5-ext": "0.10.45",
-                "es6-iterator": "0.1.3",
-                "es6-symbol": "2.0.1"
+                "d": "~0.1.1",
+                "es5-ext": "~0.10.6",
+                "es6-iterator": "~0.1.3",
+                "es6-symbol": "~2.0.1"
             },
             "dependencies": {
                 "es6-iterator": {
@@ -3612,9 +3612,9 @@
                     "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                     "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
                     "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.45",
-                        "es6-symbol": "2.0.1"
+                        "d": "~0.1.1",
+                        "es5-ext": "~0.10.5",
+                        "es6-symbol": "~2.0.1"
                     }
                 },
                 "es6-symbol": {
@@ -3622,8 +3622,8 @@
                     "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                     "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
                     "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.45"
+                        "d": "~0.1.1",
+                        "es5-ext": "~0.10.5"
                     }
                 }
             }
@@ -3645,11 +3645,11 @@
             "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
             "dev": true,
             "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.6.1"
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "esprima": {
@@ -3673,44 +3673,44 @@
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "babel-code-frame": "6.26.0",
-                "chalk": "2.4.1",
-                "concat-stream": "1.6.2",
-                "cross-spawn": "5.1.0",
-                "debug": "3.1.0",
-                "doctrine": "2.1.0",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "1.0.0",
-                "espree": "3.5.4",
-                "esquery": "1.0.1",
-                "esutils": "2.0.2",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.2",
-                "globals": "11.5.0",
-                "ignore": "3.3.8",
-                "imurmurhash": "0.1.4",
-                "inquirer": "3.3.0",
-                "is-resolvable": "1.1.0",
-                "js-yaml": "3.11.0",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.2",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.0",
-                "regexpp": "1.1.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.5.0",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
+                "ajv": "^5.3.0",
+                "babel-code-frame": "^6.22.0",
+                "chalk": "^2.1.0",
+                "concat-stream": "^1.6.0",
+                "cross-spawn": "^5.1.0",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^3.7.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^3.5.4",
+                "esquery": "^1.0.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.0.1",
+                "ignore": "^3.3.3",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^3.0.6",
+                "is-resolvable": "^1.0.0",
+                "js-yaml": "^3.9.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^1.0.1",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.3.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "~2.0.1",
                 "table": "4.0.2",
-                "text-table": "0.2.0"
+                "text-table": "~0.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -3746,8 +3746,8 @@
                     "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "4.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -3756,7 +3756,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -3767,7 +3767,7 @@
             "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
             "dev": true,
             "requires": {
-                "get-stdin": "5.0.1"
+                "get-stdin": "^5.0.1"
             }
         },
         "eslint-plugin-prettier": {
@@ -3776,8 +3776,8 @@
             "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
             "dev": true,
             "requires": {
-                "fast-diff": "1.1.2",
-                "jest-docblock": "21.2.0"
+                "fast-diff": "^1.1.1",
+                "jest-docblock": "^21.0.0"
             },
             "dependencies": {
                 "jest-docblock": {
@@ -3794,8 +3794,8 @@
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "eslint-visitor-keys": {
@@ -3810,8 +3810,8 @@
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "acorn-jsx": "3.0.1"
+                "acorn": "^5.5.0",
+                "acorn-jsx": "^3.0.0"
             }
         },
         "esprima": {
@@ -3825,7 +3825,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -3834,7 +3834,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -3860,8 +3860,8 @@
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.45"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             },
             "dependencies": {
                 "d": {
@@ -3869,7 +3869,7 @@
                     "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
                     "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
                     "requires": {
-                        "es5-ext": "0.10.45"
+                        "es5-ext": "^0.10.9"
                     }
                 }
             }
@@ -3880,13 +3880,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "events": {
@@ -3901,8 +3901,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "1.3.4",
-                "safe-buffer": "5.1.2"
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "exec-sh": {
@@ -3911,7 +3911,7 @@
             "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
             "dev": true,
             "requires": {
-                "merge": "1.2.0"
+                "merge": "^1.1.3"
             }
         },
         "execa": {
@@ -3920,13 +3920,13 @@
             "integrity": "sha1-rbfOYs+YUHH2BYDetKiLnjRxLQE=",
             "dev": true,
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "exit": {
@@ -3941,13 +3941,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -3956,7 +3956,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3965,7 +3965,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -3976,7 +3976,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             },
             "dependencies": {
                 "fill-range": {
@@ -3985,11 +3985,11 @@
                     "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "3.0.0",
-                        "repeat-element": "1.1.2",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^3.0.0",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "is-number": {
@@ -3998,7 +3998,7 @@
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "isobject": {
@@ -4018,7 +4018,7 @@
             "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.1"
             }
         },
         "expect": {
@@ -4027,12 +4027,12 @@
             "integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "jest-diff": "23.0.1",
-                "jest-get-type": "22.4.3",
-                "jest-matcher-utils": "23.0.1",
-                "jest-message-util": "23.1.0",
-                "jest-regex-util": "23.0.0"
+                "ansi-styles": "^3.2.0",
+                "jest-diff": "^23.0.1",
+                "jest-get-type": "^22.1.0",
+                "jest-matcher-utils": "^23.0.1",
+                "jest-message-util": "^23.1.0",
+                "jest-regex-util": "^23.0.0"
             }
         },
         "expect-puppeteer": {
@@ -4052,8 +4052,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -4062,7 +4062,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -4073,9 +4073,9 @@
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.19",
-                "tmp": "0.0.33"
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
             }
         },
         "extglob": {
@@ -4084,14 +4084,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -4100,7 +4100,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -4109,7 +4109,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4118,7 +4118,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -4127,7 +4127,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -4136,9 +4136,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "kind-of": {
@@ -4172,10 +4172,10 @@
             "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "foreach": "2.0.5",
+                "acorn": "^5.0.0",
+                "foreach": "^2.0.5",
                 "isarray": "0.0.1",
-                "object-keys": "1.0.11"
+                "object-keys": "^1.0.6"
             },
             "dependencies": {
                 "isarray": {
@@ -4214,7 +4214,7 @@
             "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.3.2"
             }
         },
         "fb-watchman": {
@@ -4223,7 +4223,7 @@
             "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
             "dev": true,
             "requires": {
-                "bser": "2.0.0"
+                "bser": "^2.0.0"
             }
         },
         "fd-slicer": {
@@ -4232,7 +4232,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "figures": {
@@ -4240,8 +4240,8 @@
             "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
             "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
             }
         },
         "file-contents": {
@@ -4250,18 +4250,18 @@
             "integrity": "sha1-oJOf7RuM2hWAJm/Gt1OiMvtG3lM=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "file-stat": "0.2.3",
-                "fs-exists-sync": "0.1.0",
-                "graceful-fs": "4.1.11",
-                "is-buffer": "1.1.6",
-                "isobject": "2.1.0",
-                "lazy-cache": "2.0.2",
-                "strip-bom-buffer": "0.1.1",
-                "strip-bom-string": "0.1.2",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "file-stat": "^0.2.3",
+                "fs-exists-sync": "^0.1.0",
+                "graceful-fs": "^4.1.4",
+                "is-buffer": "^1.1.3",
+                "isobject": "^2.1.0",
+                "lazy-cache": "^2.0.1",
+                "strip-bom-buffer": "^0.1.1",
+                "strip-bom-string": "^0.1.2",
+                "through2": "^2.0.1",
+                "vinyl": "^1.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -4270,7 +4270,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -4279,7 +4279,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "isobject": {
@@ -4297,7 +4297,7 @@
                     "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
                     "dev": true,
                     "requires": {
-                        "set-getter": "0.1.0"
+                        "set-getter": "^0.1.0"
                     }
                 }
             }
@@ -4308,8 +4308,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "file-stat": {
@@ -4318,10 +4318,10 @@
             "integrity": "sha1-Rpp+kn1pMAeWJM2zgQlAVFbLBqk=",
             "dev": true,
             "requires": {
-                "fs-exists-sync": "0.1.0",
-                "graceful-fs": "4.1.11",
-                "lazy-cache": "2.0.2",
-                "through2": "2.0.3"
+                "fs-exists-sync": "^0.1.0",
+                "graceful-fs": "^4.1.4",
+                "lazy-cache": "^2.0.1",
+                "through2": "^2.0.1"
             },
             "dependencies": {
                 "lazy-cache": {
@@ -4330,7 +4330,7 @@
                     "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
                     "dev": true,
                     "requires": {
-                        "set-getter": "0.1.0"
+                        "set-getter": "^0.1.0"
                     }
                 }
             }
@@ -4343,10 +4343,11 @@
         },
         "filer": {
             "version": "github:humphd/filer#a3bfd5dd08d5f245e90d97dafb3428769b437e62",
+            "from": "github:humphd/filer#a3bfd5d",
             "requires": {
-                "base64-arraybuffer": "0.1.5",
-                "bower": "1.3.12",
-                "minimatch": "1.0.0"
+                "base64-arraybuffer": "^0.1.2",
+                "bower": "~1.3.8",
+                "minimatch": "^1.0.0"
             },
             "dependencies": {
                 "lru-cache": {
@@ -4359,8 +4360,8 @@
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                     "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
@@ -4371,8 +4372,8 @@
             "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "minimatch": "3.0.4"
+                "glob": "^7.0.3",
+                "minimatch": "^3.0.3"
             }
         },
         "filesize": {
@@ -4387,10 +4388,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4399,7 +4400,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -4410,8 +4411,8 @@
             "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
             "dev": true,
             "requires": {
-                "fs-exists-sync": "0.1.0",
-                "resolve-dir": "0.1.1"
+                "fs-exists-sync": "^0.1.0",
+                "resolve-dir": "^0.1.0"
             }
         },
         "find-pkg": {
@@ -4420,7 +4421,7 @@
             "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
             "dev": true,
             "requires": {
-                "find-file-up": "0.1.3"
+                "find-file-up": "^0.1.2"
             }
         },
         "find-up": {
@@ -4429,7 +4430,7 @@
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "flat-cache": {
@@ -4438,10 +4439,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "del": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "write": "^0.2.1"
             }
         },
         "flatten": {
@@ -4462,7 +4463,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "foreach": {
@@ -4481,9 +4482,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
@@ -4492,7 +4493,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "fresh": {
@@ -4525,8 +4526,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.10.0"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -4552,8 +4553,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "balanced-match": {
@@ -4566,7 +4567,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -4630,7 +4631,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
@@ -4645,14 +4646,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
@@ -4661,12 +4662,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -4681,7 +4682,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "ignore-walk": {
@@ -4690,7 +4691,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
@@ -4699,8 +4700,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -4719,7 +4720,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -4733,7 +4734,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -4746,8 +4747,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
@@ -4756,7 +4757,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mkdirp": {
@@ -4779,9 +4780,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -4790,16 +4791,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.7",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -4808,8 +4809,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npm-bundled": {
@@ -4824,8 +4825,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -4834,10 +4835,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -4856,7 +4857,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -4877,8 +4878,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -4899,10 +4900,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.5.1",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -4919,13 +4920,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
@@ -4934,7 +4935,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -4977,9 +4978,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -4988,7 +4989,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -4996,7 +4997,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -5011,13 +5012,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -5032,7 +5033,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -5052,10 +5053,10 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "fstream-ignore": {
@@ -5063,9 +5064,9 @@
             "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
             "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
             "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
+                "fstream": "^1.0.0",
+                "inherits": "2",
+                "minimatch": "^3.0.0"
             }
         },
         "function-bind": {
@@ -5115,7 +5116,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -5123,12 +5124,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -5137,8 +5138,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "glob-parent": {
@@ -5147,7 +5148,7 @@
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             }
         },
         "glob-slash": {
@@ -5162,9 +5163,9 @@
             "integrity": "sha1-dHoOW7IiZC7hDT4FRD4QlJPLD44=",
             "dev": true,
             "requires": {
-                "glob-slash": "1.0.0",
-                "lodash.isobject": "2.4.1",
-                "toxic": "1.0.0"
+                "glob-slash": "^1.0.0",
+                "lodash.isobject": "^2.4.1",
+                "toxic": "^1.0.0"
             }
         },
         "global-modules": {
@@ -5173,8 +5174,8 @@
             "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
             "dev": true,
             "requires": {
-                "global-prefix": "0.1.5",
-                "is-windows": "0.2.0"
+                "global-prefix": "^0.1.4",
+                "is-windows": "^0.2.0"
             },
             "dependencies": {
                 "is-windows": {
@@ -5191,10 +5192,10 @@
             "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "0.2.0",
-                "which": "1.3.0"
+                "homedir-polyfill": "^1.0.0",
+                "ini": "^1.3.4",
+                "is-windows": "^0.2.0",
+                "which": "^1.2.12"
             },
             "dependencies": {
                 "is-windows": {
@@ -5216,7 +5217,7 @@
             "resolved": "https://registry.npmjs.org/got/-/got-0.3.0.tgz",
             "integrity": "sha1-iI7GbKS8c1qwidvpWUltD3lIVJM=",
             "requires": {
-                "object-assign": "0.3.1"
+                "object-assign": "^0.3.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -5237,8 +5238,8 @@
             "integrity": "sha1-W55reMODJFLSuiuxy4MPlidkEKw=",
             "dev": true,
             "requires": {
-                "brfs": "1.6.1",
-                "unicode-trie": "0.3.1"
+                "brfs": "^1.2.0",
+                "unicode-trie": "^0.3.1"
             }
         },
         "growly": {
@@ -5252,8 +5253,8 @@
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
             "integrity": "sha1-bp1/hRSjRn+l6fgswVjs/B1ax28=",
             "requires": {
-                "optimist": "0.3.7",
-                "uglify-js": "2.3.6"
+                "optimist": "~0.3",
+                "uglify-js": "~2.3"
             },
             "dependencies": {
                 "optimist": {
@@ -5261,7 +5262,7 @@
                     "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                     "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
                     "requires": {
-                        "wordwrap": "0.0.2"
+                        "wordwrap": "~0.0.2"
                     }
                 }
             }
@@ -5276,8 +5277,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -5286,7 +5287,7 @@
             "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.0.2"
             }
         },
         "has-ansi": {
@@ -5295,7 +5296,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -5310,7 +5311,7 @@
             "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
             "dev": true,
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.1"
             }
         },
         "has-value": {
@@ -5319,9 +5320,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -5330,8 +5331,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5340,7 +5341,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5351,8 +5352,8 @@
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "hash.js": {
@@ -5361,8 +5362,8 @@
             "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "hawk": {
@@ -5370,10 +5371,10 @@
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
             "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
             "requires": {
-                "boom": "0.4.2",
-                "cryptiles": "0.2.2",
-                "hoek": "0.9.1",
-                "sntp": "0.2.4"
+                "boom": "0.4.x",
+                "cryptiles": "0.2.x",
+                "hoek": "0.9.x",
+                "sntp": "0.2.x"
             }
         },
         "hmac-drbg": {
@@ -5382,9 +5383,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "1.1.3",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "hoek": {
@@ -5398,8 +5399,8 @@
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
             }
         },
         "homedir-polyfill": {
@@ -5408,7 +5409,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -5429,7 +5430,7 @@
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "dev": true,
             "requires": {
-                "whatwg-encoding": "1.0.3"
+                "whatwg-encoding": "^1.0.1"
             }
         },
         "htmlnano": {
@@ -5438,12 +5439,12 @@
             "integrity": "sha512-lVV5h1BOz5LUWSew6S0o0DeXC7kNyRoBP+JP37mXS/Wrgr7nSrOPsuhob9prMz09a/6G+3tdwuKrixwwqSl8/Q==",
             "dev": true,
             "requires": {
-                "cssnano": "3.10.0",
-                "object-assign": "4.1.1",
-                "posthtml": "0.11.3",
-                "posthtml-render": "1.1.4",
-                "svgo": "1.0.5",
-                "uglify-es": "3.3.9"
+                "cssnano": "^3.4.0",
+                "object-assign": "^4.0.1",
+                "posthtml": "^0.11.3",
+                "posthtml-render": "^1.1.3",
+                "svgo": "^1.0.5",
+                "uglify-es": "^3.3.9"
             },
             "dependencies": {
                 "coa": {
@@ -5452,7 +5453,7 @@
                     "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
                     "dev": true,
                     "requires": {
-                        "q": "1.5.1"
+                        "q": "^1.1.2"
                     }
                 },
                 "commander": {
@@ -5476,8 +5477,8 @@
                             "integrity": "sha512-BAYp9FyN4jLXjfvRpTDchBllDptqlK9I7OsagXCG9Am5C+5jc8eRZHgqb9x500W2OKS14MMlpQc/nmh/aA7TEQ==",
                             "dev": true,
                             "requires": {
-                                "mdn-data": "1.1.4",
-                                "source-map": "0.5.7"
+                                "mdn-data": "^1.0.0",
+                                "source-map": "^0.5.3"
                             }
                         }
                     }
@@ -5494,8 +5495,8 @@
                     "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "4.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "q": {
@@ -5510,20 +5511,20 @@
                     "integrity": "sha512-nYrifviB77aNKDNKKyuay3M9aYiK6Hv5gJVDdjj2ZXTQmI8WZc8+UPLR5IpVlktJfSu3co/4XcWgrgI6seGBPg==",
                     "dev": true,
                     "requires": {
-                        "coa": "2.0.1",
-                        "colors": "1.1.2",
-                        "css-select": "1.3.0-rc0",
-                        "css-select-base-adapter": "0.1.0",
+                        "coa": "~2.0.1",
+                        "colors": "~1.1.2",
+                        "css-select": "~1.3.0-rc0",
+                        "css-select-base-adapter": "~0.1.0",
                         "css-tree": "1.0.0-alpha25",
-                        "css-url-regex": "1.1.0",
-                        "csso": "3.5.0",
-                        "js-yaml": "3.10.0",
-                        "mkdirp": "0.5.1",
-                        "object.values": "1.0.4",
-                        "sax": "1.2.4",
-                        "stable": "0.1.8",
-                        "unquote": "1.1.1",
-                        "util.promisify": "1.0.0"
+                        "css-url-regex": "^1.1.0",
+                        "csso": "^3.5.0",
+                        "js-yaml": "~3.10.0",
+                        "mkdirp": "~0.5.1",
+                        "object.values": "^1.0.4",
+                        "sax": "~1.2.4",
+                        "stable": "~0.1.6",
+                        "unquote": "~1.1.1",
+                        "util.promisify": "~1.0.0"
                     }
                 },
                 "uglify-es": {
@@ -5532,8 +5533,8 @@
                     "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
                     "dev": true,
                     "requires": {
-                        "commander": "2.13.0",
-                        "source-map": "0.6.1"
+                        "commander": "~2.13.0",
+                        "source-map": "~0.6.1"
                     },
                     "dependencies": {
                         "source-map": {
@@ -5552,12 +5553,12 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.2",
-                "domutils": "1.7.0",
-                "entities": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "http-errors": {
@@ -5566,10 +5567,10 @@
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "dev": true,
             "requires": {
-                "depd": "1.1.2",
+                "depd": "~1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.4.0"
+                "statuses": ">= 1.4.0 < 2"
             }
         },
         "http-signature": {
@@ -5577,9 +5578,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.2"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "https-browserify": {
@@ -5594,8 +5595,8 @@
             "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
             "dev": true,
             "requires": {
-                "agent-base": "4.2.0",
-                "debug": "3.1.0"
+                "agent-base": "^4.1.0",
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -5615,9 +5616,9 @@
             "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
             "dev": true,
             "requires": {
-                "is-ci": "1.1.0",
-                "normalize-path": "1.0.0",
-                "strip-indent": "2.0.0"
+                "is-ci": "^1.0.10",
+                "normalize-path": "^1.0.0",
+                "strip-indent": "^2.0.0"
             }
         },
         "iconv-lite": {
@@ -5644,8 +5645,8 @@
             "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "2.0.0",
-                "resolve-cwd": "2.0.0"
+                "pkg-dir": "^2.0.0",
+                "resolve-cwd": "^2.0.0"
             }
         },
         "imurmurhash": {
@@ -5671,8 +5672,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -5691,20 +5692,20 @@
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.1.0",
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.2.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.10",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rx-lite": "4.0.8",
-                "rx-lite-aggregates": "4.0.8",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5719,7 +5720,7 @@
                     "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
                     "dev": true,
                     "requires": {
-                        "escape-string-regexp": "1.0.5"
+                        "escape-string-regexp": "^1.0.5"
                     }
                 },
                 "strip-ansi": {
@@ -5728,7 +5729,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -5738,15 +5739,15 @@
             "resolved": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
             "integrity": "sha1-dtZTxcDYBIsDzbpjhaaUj3RhSvA=",
             "requires": {
-                "async": "0.9.2",
-                "chalk": "0.5.1",
-                "configstore": "0.3.2",
-                "inquirer": "0.6.0",
-                "lodash.debounce": "2.4.1",
-                "object-assign": "1.0.0",
-                "os-name": "1.0.3",
-                "request": "2.87.0",
-                "tough-cookie": "0.12.1"
+                "async": "^0.9.0",
+                "chalk": "^0.5.1",
+                "configstore": "^0.3.1",
+                "inquirer": "^0.6.0",
+                "lodash.debounce": "^2.4.1",
+                "object-assign": "^1.0.0",
+                "os-name": "^1.0.0",
+                "request": "^2.40.0",
+                "tough-cookie": "^0.12.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5769,11 +5770,11 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                     "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
                     "requires": {
-                        "ansi-styles": "1.1.0",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "0.1.0",
-                        "strip-ansi": "0.3.0",
-                        "supports-color": "0.2.0"
+                        "ansi-styles": "^1.1.0",
+                        "escape-string-regexp": "^1.0.0",
+                        "has-ansi": "^0.1.0",
+                        "strip-ansi": "^0.3.0",
+                        "supports-color": "^0.2.0"
                     }
                 },
                 "has-ansi": {
@@ -5781,7 +5782,7 @@
                     "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                     "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.0"
                     }
                 },
                 "inquirer": {
@@ -5789,13 +5790,13 @@
                     "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
                     "integrity": "sha1-YU17s+SPnmqAKOlKDDjyPvKYI9M=",
                     "requires": {
-                        "chalk": "0.5.1",
-                        "cli-color": "0.3.3",
-                        "lodash": "2.4.2",
+                        "chalk": "^0.5.0",
+                        "cli-color": "~0.3.2",
+                        "lodash": "~2.4.1",
                         "mute-stream": "0.0.4",
-                        "readline2": "0.1.1",
-                        "rx": "2.5.3",
-                        "through": "2.3.8"
+                        "readline2": "~0.1.0",
+                        "rx": "^2.2.27",
+                        "through": "~2.3.4"
                     }
                 },
                 "lodash": {
@@ -5818,7 +5819,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                     "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.1"
                     }
                 },
                 "supports-color": {
@@ -5831,7 +5832,7 @@
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                     "integrity": "sha1-giDH4hq9WxPZaAQlS9WoHr8sfWI=",
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": ">=0.2.0"
                     }
                 }
             }
@@ -5847,7 +5848,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "1.3.1"
+                "loose-envify": "^1.0.0"
             }
         },
         "invert-kv": {
@@ -5862,8 +5863,8 @@
             "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
             "dev": true,
             "requires": {
-                "is-relative": "0.2.1",
-                "is-windows": "0.2.0"
+                "is-relative": "^0.2.1",
+                "is-windows": "^0.2.0"
             },
             "dependencies": {
                 "is-windows": {
@@ -5886,7 +5887,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-arrayish": {
@@ -5901,7 +5902,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -5916,7 +5917,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-callable": {
@@ -5931,7 +5932,7 @@
             "integrity": "sha1-JH5BYueGDOu9rzC3dNawrH3P56U=",
             "dev": true,
             "requires": {
-                "ci-info": "1.1.3"
+                "ci-info": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -5940,7 +5941,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-date-object": {
@@ -5955,9 +5956,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5980,7 +5981,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -6001,7 +6002,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -6022,7 +6023,7 @@
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "is-number": {
@@ -6031,7 +6032,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-odd": {
@@ -6040,7 +6041,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -6063,7 +6064,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -6072,7 +6073,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -6087,7 +6088,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -6114,7 +6115,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "1.0.1"
+                "has": "^1.0.1"
             }
         },
         "is-relative": {
@@ -6123,7 +6124,7 @@
             "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
             "dev": true,
             "requires": {
-                "is-unc-path": "0.1.2"
+                "is-unc-path": "^0.1.1"
             }
         },
         "is-resolvable": {
@@ -6149,7 +6150,7 @@
             "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
             "dev": true,
             "requires": {
-                "html-comment-regex": "1.1.1"
+                "html-comment-regex": "^1.1.0"
             }
         },
         "is-symbol": {
@@ -6169,7 +6170,7 @@
             "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.0"
             }
         },
         "is-url": {
@@ -6231,18 +6232,18 @@
             "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
             "dev": true,
             "requires": {
-                "async": "2.6.1",
-                "compare-versions": "3.2.1",
-                "fileset": "2.0.3",
-                "istanbul-lib-coverage": "1.2.0",
-                "istanbul-lib-hook": "1.2.0",
-                "istanbul-lib-instrument": "1.10.1",
-                "istanbul-lib-report": "1.1.4",
-                "istanbul-lib-source-maps": "1.2.5",
-                "istanbul-reports": "1.3.0",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "once": "1.4.0"
+                "async": "^2.1.4",
+                "compare-versions": "^3.1.0",
+                "fileset": "^2.0.2",
+                "istanbul-lib-coverage": "^1.2.0",
+                "istanbul-lib-hook": "^1.2.0",
+                "istanbul-lib-instrument": "^1.10.1",
+                "istanbul-lib-report": "^1.1.4",
+                "istanbul-lib-source-maps": "^1.2.4",
+                "istanbul-reports": "^1.3.0",
+                "js-yaml": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "once": "^1.4.0"
             },
             "dependencies": {
                 "async": {
@@ -6251,7 +6252,7 @@
                     "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.10"
+                        "lodash": "^4.17.10"
                     }
                 }
             }
@@ -6268,7 +6269,7 @@
             "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
             "dev": true,
             "requires": {
-                "append-transform": "0.4.0"
+                "append-transform": "^0.4.0"
             }
         },
         "istanbul-lib-instrument": {
@@ -6277,13 +6278,13 @@
             "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
             "dev": true,
             "requires": {
-                "babel-generator": "6.26.1",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "istanbul-lib-coverage": "1.2.0",
-                "semver": "5.5.0"
+                "babel-generator": "^6.18.0",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.18.0",
+                "babel-types": "^6.18.0",
+                "babylon": "^6.18.0",
+                "istanbul-lib-coverage": "^1.2.0",
+                "semver": "^5.3.0"
             }
         },
         "istanbul-lib-report": {
@@ -6292,10 +6293,10 @@
             "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "1.2.0",
-                "mkdirp": "0.5.1",
-                "path-parse": "1.0.5",
-                "supports-color": "3.2.3"
+                "istanbul-lib-coverage": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "path-parse": "^1.0.5",
+                "supports-color": "^3.1.2"
             },
             "dependencies": {
                 "has-flag": {
@@ -6310,7 +6311,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -6321,11 +6322,11 @@
             "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "istanbul-lib-coverage": "1.2.0",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "source-map": "0.5.7"
+                "debug": "^3.1.0",
+                "istanbul-lib-coverage": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.1",
+                "source-map": "^0.5.3"
             },
             "dependencies": {
                 "debug": {
@@ -6345,7 +6346,7 @@
             "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
             "dev": true,
             "requires": {
-                "handlebars": "4.0.11"
+                "handlebars": "^4.0.3"
             },
             "dependencies": {
                 "async": {
@@ -6360,10 +6361,10 @@
                     "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
                     "dev": true,
                     "requires": {
-                        "async": "1.5.2",
-                        "optimist": "0.6.1",
-                        "source-map": "0.4.4",
-                        "uglify-js": "2.8.29"
+                        "async": "^1.4.0",
+                        "optimist": "^0.6.1",
+                        "source-map": "^0.4.4",
+                        "uglify-js": "^2.6"
                     }
                 },
                 "source-map": {
@@ -6372,7 +6373,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 },
                 "uglify-js": {
@@ -6382,9 +6383,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     },
                     "dependencies": {
                         "source-map": {
@@ -6403,9 +6404,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -6417,8 +6418,8 @@
             "integrity": "sha1-u7f4kxAKEadC3YvQ0EelSwlorRo=",
             "dev": true,
             "requires": {
-                "import-local": "1.0.0",
-                "jest-cli": "23.1.0"
+                "import-local": "^1.0.0",
+                "jest-cli": "^23.1.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -6433,41 +6434,41 @@
                     "integrity": "sha1-64vdTODRUlCJLjGtm2m8mdKo9r8=",
                     "dev": true,
                     "requires": {
-                        "ansi-escapes": "3.1.0",
-                        "chalk": "2.4.1",
-                        "exit": "0.1.2",
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "import-local": "1.0.0",
-                        "is-ci": "1.1.0",
-                        "istanbul-api": "1.3.1",
-                        "istanbul-lib-coverage": "1.2.0",
-                        "istanbul-lib-instrument": "1.10.1",
-                        "istanbul-lib-source-maps": "1.2.5",
-                        "jest-changed-files": "23.0.1",
-                        "jest-config": "23.1.0",
-                        "jest-environment-jsdom": "23.1.0",
-                        "jest-get-type": "22.4.3",
-                        "jest-haste-map": "23.1.0",
-                        "jest-message-util": "23.1.0",
-                        "jest-regex-util": "23.0.0",
-                        "jest-resolve-dependencies": "23.0.1",
-                        "jest-runner": "23.1.0",
-                        "jest-runtime": "23.1.0",
-                        "jest-snapshot": "23.0.1",
-                        "jest-util": "23.1.0",
-                        "jest-validate": "23.0.1",
-                        "jest-watcher": "23.1.0",
-                        "jest-worker": "23.0.1",
-                        "micromatch": "2.3.11",
-                        "node-notifier": "5.2.1",
-                        "realpath-native": "1.0.0",
-                        "rimraf": "2.6.2",
-                        "slash": "1.0.0",
-                        "string-length": "2.0.0",
-                        "strip-ansi": "4.0.0",
-                        "which": "1.3.0",
-                        "yargs": "11.0.0"
+                        "ansi-escapes": "^3.0.0",
+                        "chalk": "^2.0.1",
+                        "exit": "^0.1.2",
+                        "glob": "^7.1.2",
+                        "graceful-fs": "^4.1.11",
+                        "import-local": "^1.0.0",
+                        "is-ci": "^1.0.10",
+                        "istanbul-api": "^1.3.1",
+                        "istanbul-lib-coverage": "^1.2.0",
+                        "istanbul-lib-instrument": "^1.10.1",
+                        "istanbul-lib-source-maps": "^1.2.4",
+                        "jest-changed-files": "^23.0.1",
+                        "jest-config": "^23.1.0",
+                        "jest-environment-jsdom": "^23.1.0",
+                        "jest-get-type": "^22.1.0",
+                        "jest-haste-map": "^23.1.0",
+                        "jest-message-util": "^23.1.0",
+                        "jest-regex-util": "^23.0.0",
+                        "jest-resolve-dependencies": "^23.0.1",
+                        "jest-runner": "^23.1.0",
+                        "jest-runtime": "^23.1.0",
+                        "jest-snapshot": "^23.0.1",
+                        "jest-util": "^23.1.0",
+                        "jest-validate": "^23.0.1",
+                        "jest-watcher": "^23.1.0",
+                        "jest-worker": "^23.0.1",
+                        "micromatch": "^2.3.11",
+                        "node-notifier": "^5.2.1",
+                        "realpath-native": "^1.0.0",
+                        "rimraf": "^2.5.4",
+                        "slash": "^1.0.0",
+                        "string-length": "^2.0.0",
+                        "strip-ansi": "^4.0.0",
+                        "which": "^1.2.12",
+                        "yargs": "^11.0.0"
                     }
                 },
                 "string-length": {
@@ -6476,8 +6477,8 @@
                     "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
                     "dev": true,
                     "requires": {
-                        "astral-regex": "1.0.0",
-                        "strip-ansi": "4.0.0"
+                        "astral-regex": "^1.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -6486,7 +6487,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -6497,7 +6498,7 @@
             "integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
             "dev": true,
             "requires": {
-                "throat": "4.1.0"
+                "throat": "^4.0.0"
             }
         },
         "jest-config": {
@@ -6506,19 +6507,19 @@
             "integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
             "dev": true,
             "requires": {
-                "babel-core": "6.26.3",
-                "babel-jest": "23.0.1",
-                "chalk": "2.4.1",
-                "glob": "7.1.2",
-                "jest-environment-jsdom": "23.1.0",
-                "jest-environment-node": "23.1.0",
-                "jest-get-type": "22.4.3",
-                "jest-jasmine2": "23.1.0",
-                "jest-regex-util": "23.0.0",
-                "jest-resolve": "23.1.0",
-                "jest-util": "23.1.0",
-                "jest-validate": "23.0.1",
-                "pretty-format": "23.0.1"
+                "babel-core": "^6.0.0",
+                "babel-jest": "^23.0.1",
+                "chalk": "^2.0.1",
+                "glob": "^7.1.1",
+                "jest-environment-jsdom": "^23.1.0",
+                "jest-environment-node": "^23.1.0",
+                "jest-get-type": "^22.1.0",
+                "jest-jasmine2": "^23.1.0",
+                "jest-regex-util": "^23.0.0",
+                "jest-resolve": "^23.1.0",
+                "jest-util": "^23.1.0",
+                "jest-validate": "^23.0.1",
+                "pretty-format": "^23.0.1"
             },
             "dependencies": {
                 "jest-environment-node": {
@@ -6527,8 +6528,8 @@
                     "integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
                     "dev": true,
                     "requires": {
-                        "jest-mock": "23.1.0",
-                        "jest-util": "23.1.0"
+                        "jest-mock": "^23.1.0",
+                        "jest-util": "^23.1.0"
                     }
                 }
             }
@@ -6539,10 +6540,10 @@
             "integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "diff": "3.5.0",
-                "jest-get-type": "22.4.3",
-                "pretty-format": "23.0.1"
+                "chalk": "^2.0.1",
+                "diff": "^3.2.0",
+                "jest-get-type": "^22.1.0",
+                "pretty-format": "^23.0.1"
             }
         },
         "jest-docblock": {
@@ -6551,7 +6552,7 @@
             "integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
             "dev": true,
             "requires": {
-                "detect-newline": "2.1.0"
+                "detect-newline": "^2.1.0"
             }
         },
         "jest-each": {
@@ -6560,8 +6561,8 @@
             "integrity": "sha1-FhRrWSw1SGelrl4TzfFcbGW2lsY=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "pretty-format": "23.0.1"
+                "chalk": "^2.0.1",
+                "pretty-format": "^23.0.1"
             }
         },
         "jest-environment-jsdom": {
@@ -6570,9 +6571,9 @@
             "integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
             "dev": true,
             "requires": {
-                "jest-mock": "23.1.0",
-                "jest-util": "23.1.0",
-                "jsdom": "11.11.0"
+                "jest-mock": "^23.1.0",
+                "jest-util": "^23.1.0",
+                "jsdom": "^11.5.1"
             }
         },
         "jest-environment-node": {
@@ -6581,8 +6582,8 @@
             "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
             "dev": true,
             "requires": {
-                "jest-mock": "22.4.3",
-                "jest-util": "22.4.3"
+                "jest-mock": "^22.4.3",
+                "jest-util": "^22.4.3"
             },
             "dependencies": {
                 "callsites": {
@@ -6597,11 +6598,11 @@
                     "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "7.0.0-beta.49",
-                        "chalk": "2.4.1",
-                        "micromatch": "2.3.11",
-                        "slash": "1.0.0",
-                        "stack-utils": "1.0.1"
+                        "@babel/code-frame": "^7.0.0-beta.35",
+                        "chalk": "^2.0.1",
+                        "micromatch": "^2.3.11",
+                        "slash": "^1.0.0",
+                        "stack-utils": "^1.0.1"
                     }
                 },
                 "jest-mock": {
@@ -6616,13 +6617,13 @@
                     "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
                     "dev": true,
                     "requires": {
-                        "callsites": "2.0.0",
-                        "chalk": "2.4.1",
-                        "graceful-fs": "4.1.11",
-                        "is-ci": "1.1.0",
-                        "jest-message-util": "22.4.3",
-                        "mkdirp": "0.5.1",
-                        "source-map": "0.6.1"
+                        "callsites": "^2.0.0",
+                        "chalk": "^2.0.1",
+                        "graceful-fs": "^4.1.11",
+                        "is-ci": "^1.0.10",
+                        "jest-message-util": "^22.4.3",
+                        "mkdirp": "^0.5.1",
+                        "source-map": "^0.6.0"
                     }
                 },
                 "source-map": {
@@ -6639,13 +6640,13 @@
             "integrity": "sha1-kabS3I+gpIwpZdbfuRIiaspMs00=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "cwd": "0.10.0",
-                "lodash": "4.17.10",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "spawnd": "2.0.0",
-                "wait-port": "0.2.2"
+                "chalk": "^2.4.0",
+                "cwd": "^0.10.0",
+                "lodash": "^4.17.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.2",
+                "spawnd": "^2.0.0",
+                "wait-port": "^0.2.2"
             }
         },
         "jest-get-type": {
@@ -6660,13 +6661,13 @@
             "integrity": "sha1-GObH1ajScTb5G32YUvhd4McHTEk=",
             "dev": true,
             "requires": {
-                "fb-watchman": "2.0.0",
-                "graceful-fs": "4.1.11",
-                "jest-docblock": "23.0.1",
-                "jest-serializer": "23.0.1",
-                "jest-worker": "23.0.1",
-                "micromatch": "2.3.11",
-                "sane": "2.5.2"
+                "fb-watchman": "^2.0.0",
+                "graceful-fs": "^4.1.11",
+                "jest-docblock": "^23.0.1",
+                "jest-serializer": "^23.0.1",
+                "jest-worker": "^23.0.1",
+                "micromatch": "^2.3.11",
+                "sane": "^2.0.0"
             }
         },
         "jest-jasmine2": {
@@ -6675,17 +6676,17 @@
             "integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "co": "4.6.0",
-                "expect": "23.1.0",
-                "is-generator-fn": "1.0.0",
-                "jest-diff": "23.0.1",
-                "jest-each": "23.1.0",
-                "jest-matcher-utils": "23.0.1",
-                "jest-message-util": "23.1.0",
-                "jest-snapshot": "23.0.1",
-                "jest-util": "23.1.0",
-                "pretty-format": "23.0.1"
+                "chalk": "^2.0.1",
+                "co": "^4.6.0",
+                "expect": "^23.1.0",
+                "is-generator-fn": "^1.0.0",
+                "jest-diff": "^23.0.1",
+                "jest-each": "^23.1.0",
+                "jest-matcher-utils": "^23.0.1",
+                "jest-message-util": "^23.1.0",
+                "jest-snapshot": "^23.0.1",
+                "jest-util": "^23.1.0",
+                "pretty-format": "^23.0.1"
             }
         },
         "jest-leak-detector": {
@@ -6694,7 +6695,7 @@
             "integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
             "dev": true,
             "requires": {
-                "pretty-format": "23.0.1"
+                "pretty-format": "^23.0.1"
             }
         },
         "jest-matcher-utils": {
@@ -6703,9 +6704,9 @@
             "integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-get-type": "22.4.3",
-                "pretty-format": "23.0.1"
+                "chalk": "^2.0.1",
+                "jest-get-type": "^22.1.0",
+                "pretty-format": "^23.0.1"
             }
         },
         "jest-message-util": {
@@ -6714,11 +6715,11 @@
             "integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.49",
-                "chalk": "2.4.1",
-                "micromatch": "2.3.11",
-                "slash": "1.0.0",
-                "stack-utils": "1.0.1"
+                "@babel/code-frame": "^7.0.0-beta.35",
+                "chalk": "^2.0.1",
+                "micromatch": "^2.3.11",
+                "slash": "^1.0.0",
+                "stack-utils": "^1.0.1"
             }
         },
         "jest-mock": {
@@ -6733,8 +6734,8 @@
             "integrity": "sha1-rIhF2G/23RVNmDYczk5rechOmdw=",
             "dev": true,
             "requires": {
-                "expect-puppeteer": "3.0.1",
-                "jest-environment-puppeteer": "2.4.0"
+                "expect-puppeteer": "^3.0.1",
+                "jest-environment-puppeteer": "^2.4.0"
             }
         },
         "jest-regex-util": {
@@ -6749,9 +6750,9 @@
             "integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
             "dev": true,
             "requires": {
-                "browser-resolve": "1.11.2",
-                "chalk": "2.4.1",
-                "realpath-native": "1.0.0"
+                "browser-resolve": "^1.11.2",
+                "chalk": "^2.0.1",
+                "realpath-native": "^1.0.0"
             }
         },
         "jest-resolve-dependencies": {
@@ -6760,8 +6761,8 @@
             "integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
             "dev": true,
             "requires": {
-                "jest-regex-util": "23.0.0",
-                "jest-snapshot": "23.0.1"
+                "jest-regex-util": "^23.0.0",
+                "jest-snapshot": "^23.0.1"
             }
         },
         "jest-runner": {
@@ -6770,19 +6771,19 @@
             "integrity": "sha1-+iCpM//3MaVDKzVh5/ZCZZT6KbU=",
             "dev": true,
             "requires": {
-                "exit": "0.1.2",
-                "graceful-fs": "4.1.11",
-                "jest-config": "23.1.0",
-                "jest-docblock": "23.0.1",
-                "jest-haste-map": "23.1.0",
-                "jest-jasmine2": "23.1.0",
-                "jest-leak-detector": "23.0.1",
-                "jest-message-util": "23.1.0",
-                "jest-runtime": "23.1.0",
-                "jest-util": "23.1.0",
-                "jest-worker": "23.0.1",
-                "source-map-support": "0.5.6",
-                "throat": "4.1.0"
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.1.11",
+                "jest-config": "^23.1.0",
+                "jest-docblock": "^23.0.1",
+                "jest-haste-map": "^23.1.0",
+                "jest-jasmine2": "^23.1.0",
+                "jest-leak-detector": "^23.0.1",
+                "jest-message-util": "^23.1.0",
+                "jest-runtime": "^23.1.0",
+                "jest-util": "^23.1.0",
+                "jest-worker": "^23.0.1",
+                "source-map-support": "^0.5.6",
+                "throat": "^4.0.0"
             },
             "dependencies": {
                 "source-map": {
@@ -6797,8 +6798,8 @@
                     "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
                     "dev": true,
                     "requires": {
-                        "buffer-from": "1.0.0",
-                        "source-map": "0.6.1"
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
                     }
                 }
             }
@@ -6809,27 +6810,27 @@
             "integrity": "sha1-tK4OhyWeys/UqIS2OdsHz03WIK8=",
             "dev": true,
             "requires": {
-                "babel-core": "6.26.3",
-                "babel-plugin-istanbul": "4.1.6",
-                "chalk": "2.4.1",
-                "convert-source-map": "1.5.1",
-                "exit": "0.1.2",
-                "fast-json-stable-stringify": "2.0.0",
-                "graceful-fs": "4.1.11",
-                "jest-config": "23.1.0",
-                "jest-haste-map": "23.1.0",
-                "jest-message-util": "23.1.0",
-                "jest-regex-util": "23.0.0",
-                "jest-resolve": "23.1.0",
-                "jest-snapshot": "23.0.1",
-                "jest-util": "23.1.0",
-                "jest-validate": "23.0.1",
-                "micromatch": "2.3.11",
-                "realpath-native": "1.0.0",
-                "slash": "1.0.0",
+                "babel-core": "^6.0.0",
+                "babel-plugin-istanbul": "^4.1.6",
+                "chalk": "^2.0.1",
+                "convert-source-map": "^1.4.0",
+                "exit": "^0.1.2",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graceful-fs": "^4.1.11",
+                "jest-config": "^23.1.0",
+                "jest-haste-map": "^23.1.0",
+                "jest-message-util": "^23.1.0",
+                "jest-regex-util": "^23.0.0",
+                "jest-resolve": "^23.1.0",
+                "jest-snapshot": "^23.0.1",
+                "jest-util": "^23.1.0",
+                "jest-validate": "^23.0.1",
+                "micromatch": "^2.3.11",
+                "realpath-native": "^1.0.0",
+                "slash": "^1.0.0",
                 "strip-bom": "3.0.0",
-                "write-file-atomic": "2.3.0",
-                "yargs": "11.0.0"
+                "write-file-atomic": "^2.1.0",
+                "yargs": "^11.0.0"
             },
             "dependencies": {
                 "strip-bom": {
@@ -6852,12 +6853,12 @@
             "integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-diff": "23.0.1",
-                "jest-matcher-utils": "23.0.1",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "pretty-format": "23.0.1"
+                "chalk": "^2.0.1",
+                "jest-diff": "^23.0.1",
+                "jest-matcher-utils": "^23.0.1",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^23.0.1"
             }
         },
         "jest-util": {
@@ -6866,14 +6867,14 @@
             "integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
             "dev": true,
             "requires": {
-                "callsites": "2.0.0",
-                "chalk": "2.4.1",
-                "graceful-fs": "4.1.11",
-                "is-ci": "1.1.0",
-                "jest-message-util": "23.1.0",
-                "mkdirp": "0.5.1",
-                "slash": "1.0.0",
-                "source-map": "0.6.1"
+                "callsites": "^2.0.0",
+                "chalk": "^2.0.1",
+                "graceful-fs": "^4.1.11",
+                "is-ci": "^1.0.10",
+                "jest-message-util": "^23.1.0",
+                "mkdirp": "^0.5.1",
+                "slash": "^1.0.0",
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "callsites": {
@@ -6896,10 +6897,10 @@
             "integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-get-type": "22.4.3",
-                "leven": "2.1.0",
-                "pretty-format": "23.0.1"
+                "chalk": "^2.0.1",
+                "jest-get-type": "^22.1.0",
+                "leven": "^2.1.0",
+                "pretty-format": "^23.0.1"
             }
         },
         "jest-watcher": {
@@ -6908,9 +6909,9 @@
             "integrity": "sha1-qNWELjjZ+0r/+CPfartCpYrmzb0=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.1.0",
-                "chalk": "2.4.1",
-                "string-length": "2.0.0"
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.1",
+                "string-length": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -6925,8 +6926,8 @@
                     "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
                     "dev": true,
                     "requires": {
-                        "astral-regex": "1.0.0",
-                        "strip-ansi": "4.0.0"
+                        "astral-regex": "^1.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -6935,7 +6936,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -6946,7 +6947,7 @@
             "integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
             "dev": true,
             "requires": {
-                "merge-stream": "1.0.1"
+                "merge-stream": "^1.0.1"
             }
         },
         "js-base64": {
@@ -6961,10 +6962,10 @@
             "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
             "dev": true,
             "requires": {
-                "config-chain": "1.1.11",
-                "editorconfig": "0.13.3",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6"
+                "config-chain": "~1.1.5",
+                "editorconfig": "^0.13.2",
+                "mkdirp": "~0.5.0",
+                "nopt": "~3.0.1"
             }
         },
         "js-tokens": {
@@ -6978,8 +6979,8 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
             "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "2.7.3"
+                "argparse": "^1.0.7",
+                "esprima": "^2.6.0"
             }
         },
         "jsbn": {
@@ -6994,32 +6995,32 @@
             "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
             "dev": true,
             "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.5.3",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "cssom": "0.3.2",
-                "cssstyle": "0.3.1",
-                "data-urls": "1.0.0",
-                "domexception": "1.0.1",
-                "escodegen": "1.9.1",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.3.0",
-                "nwsapi": "2.0.1",
+                "abab": "^1.0.4",
+                "acorn": "^5.3.0",
+                "acorn-globals": "^4.1.0",
+                "array-equal": "^1.0.0",
+                "cssom": ">= 0.3.2 < 0.4.0",
+                "cssstyle": ">= 0.3.1 < 0.4.0",
+                "data-urls": "^1.0.0",
+                "domexception": "^1.0.0",
+                "escodegen": "^1.9.0",
+                "html-encoding-sniffer": "^1.0.2",
+                "left-pad": "^1.2.0",
+                "nwsapi": "^2.0.0",
                 "parse5": "4.0.0",
-                "pn": "1.1.0",
-                "request": "2.87.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.4",
-                "w3c-hr-time": "1.0.1",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-mimetype": "2.1.0",
-                "whatwg-url": "6.4.1",
-                "ws": "4.1.0",
-                "xml-name-validator": "3.0.0"
+                "pn": "^1.1.0",
+                "request": "^2.83.0",
+                "request-promise-native": "^1.0.5",
+                "sax": "^1.2.4",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.3.3",
+                "w3c-hr-time": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.3",
+                "whatwg-mimetype": "^2.1.0",
+                "whatwg-url": "^6.4.1",
+                "ws": "^4.0.0",
+                "xml-name-validator": "^3.0.0"
             }
         },
         "jsesc": {
@@ -7082,7 +7083,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "latest-version": {
@@ -7090,7 +7091,7 @@
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
             "integrity": "sha1-ra+JjV8iOA0/nEU4bv3/ChtbdQE=",
             "requires": {
-                "package-json": "0.2.0"
+                "package-json": "^0.2.0"
             }
         },
         "lazy-cache": {
@@ -7106,7 +7107,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "left-pad": {
@@ -7127,8 +7128,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "load-json-file": {
@@ -7137,11 +7138,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "locate-path": {
@@ -7150,8 +7151,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lockfile": {
@@ -7159,7 +7160,7 @@
             "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
             "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
             "requires": {
-                "signal-exit": "3.0.2"
+                "signal-exit": "^3.0.2"
             }
         },
         "lodash": {
@@ -7189,9 +7190,9 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
             "integrity": "sha1-2M6tJG7EuSbouFZ4/Dlr/rqMxvw=",
             "requires": {
-                "lodash.isfunction": "2.4.1",
-                "lodash.isobject": "2.4.1",
-                "lodash.now": "2.4.1"
+                "lodash.isfunction": "~2.4.1",
+                "lodash.isobject": "~2.4.1",
+                "lodash.now": "~2.4.1"
             }
         },
         "lodash.isfunction": {
@@ -7204,7 +7205,7 @@
             "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
             "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
             "requires": {
-                "lodash._objecttypes": "2.4.1"
+                "lodash._objecttypes": "~2.4.1"
             }
         },
         "lodash.memoize": {
@@ -7218,7 +7219,7 @@
             "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
             "integrity": "sha1-aHIVZQBSUYX6+WeFu3/n/hW1YsY=",
             "requires": {
-                "lodash._isnative": "2.4.1"
+                "lodash._isnative": "~2.4.1"
             }
         },
         "lodash.sortby": {
@@ -7239,8 +7240,8 @@
             "integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
             "dev": true,
             "requires": {
-                "ansi-green": "0.1.1",
-                "success-symbol": "0.1.0"
+                "ansi-green": "^0.1.1",
+                "success-symbol": "^0.1.0"
             }
         },
         "log-symbols": {
@@ -7249,7 +7250,7 @@
             "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1"
+                "chalk": "^2.0.1"
             }
         },
         "longest": {
@@ -7264,7 +7265,7 @@
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
             "dev": true,
             "requires": {
-                "js-tokens": "3.0.2"
+                "js-tokens": "^3.0.0"
             }
         },
         "lru-cache": {
@@ -7273,8 +7274,8 @@
             "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "lru-queue": {
@@ -7282,7 +7283,7 @@
             "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "requires": {
-                "es5-ext": "0.10.45"
+                "es5-ext": "~0.10.2"
             }
         },
         "magic-string": {
@@ -7291,7 +7292,7 @@
             "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
             "dev": true,
             "requires": {
-                "vlq": "0.2.3"
+                "vlq": "^0.2.2"
             }
         },
         "makeerror": {
@@ -7300,7 +7301,7 @@
             "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
             "dev": true,
             "requires": {
-                "tmpl": "1.0.4"
+                "tmpl": "1.0.x"
             }
         },
         "map-cache": {
@@ -7321,7 +7322,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "matched": {
@@ -7330,15 +7331,15 @@
             "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "async-array-reduce": "0.2.1",
-                "extend-shallow": "2.0.1",
-                "fs-exists-sync": "0.1.0",
-                "glob": "7.1.2",
-                "has-glob": "0.1.1",
-                "is-valid-glob": "0.3.0",
-                "lazy-cache": "2.0.2",
-                "resolve-dir": "0.1.1"
+                "arr-union": "^3.1.0",
+                "async-array-reduce": "^0.2.0",
+                "extend-shallow": "^2.0.1",
+                "fs-exists-sync": "^0.1.0",
+                "glob": "^7.0.5",
+                "has-glob": "^0.1.1",
+                "is-valid-glob": "^0.3.0",
+                "lazy-cache": "^2.0.1",
+                "resolve-dir": "^0.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -7347,7 +7348,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "lazy-cache": {
@@ -7356,7 +7357,7 @@
                     "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
                     "dev": true,
                     "requires": {
-                        "set-getter": "0.1.0"
+                        "set-getter": "^0.1.0"
                     }
                 }
             }
@@ -7379,8 +7380,8 @@
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "mdn-data": {
@@ -7395,7 +7396,7 @@
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "memoizee": {
@@ -7403,13 +7404,13 @@
             "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
             "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
             "requires": {
-                "d": "0.1.1",
-                "es5-ext": "0.10.45",
-                "es6-weak-map": "0.1.4",
-                "event-emitter": "0.3.5",
-                "lru-queue": "0.1.0",
-                "next-tick": "0.2.2",
-                "timers-ext": "0.1.5"
+                "d": "~0.1.1",
+                "es5-ext": "~0.10.11",
+                "es6-weak-map": "~0.1.4",
+                "event-emitter": "~0.3.4",
+                "lru-queue": "0.1",
+                "next-tick": "~0.2.2",
+                "timers-ext": "0.1"
             },
             "dependencies": {
                 "next-tick": {
@@ -7431,7 +7432,7 @@
             "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
             }
         },
         "merge-stream": {
@@ -7440,7 +7441,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -7449,19 +7450,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -7470,7 +7471,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -7485,9 +7486,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "expand-brackets": {
@@ -7496,7 +7497,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -7505,7 +7506,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "normalize-path": {
@@ -7514,7 +7515,7 @@
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                     "dev": true,
                     "requires": {
-                        "remove-trailing-separator": "1.1.0"
+                        "remove-trailing-separator": "^1.0.1"
                     }
                 }
             }
@@ -7525,8 +7526,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0"
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
             }
         },
         "mime": {
@@ -7545,7 +7546,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "mimic-fn": {
@@ -7571,7 +7572,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -7585,8 +7586,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -7595,7 +7596,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -7647,18 +7648,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -7709,28 +7710,28 @@
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
             "requires": {
-                "assert": "1.4.1",
-                "browserify-zlib": "0.2.0",
-                "buffer": "4.9.1",
-                "console-browserify": "1.1.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "domain-browser": "1.2.0",
-                "events": "1.1.1",
-                "https-browserify": "1.0.0",
-                "os-browserify": "0.3.0",
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^1.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "readable-stream": "2.3.6",
-                "stream-browserify": "2.0.1",
-                "stream-http": "2.8.3",
-                "string_decoder": "1.1.1",
-                "timers-browserify": "2.0.10",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
-                "url": "0.11.0",
-                "util": "0.10.4",
+                "url": "^0.11.0",
+                "util": "^0.10.3",
                 "vm-browserify": "0.0.4"
             }
         },
@@ -7740,10 +7741,10 @@
             "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
             "dev": true,
             "requires": {
-                "growly": "1.3.0",
-                "semver": "5.5.0",
-                "shellwords": "0.1.1",
-                "which": "1.3.0"
+                "growly": "^1.3.0",
+                "semver": "^5.4.1",
+                "shellwords": "^0.1.1",
+                "which": "^1.3.0"
             }
         },
         "nopt": {
@@ -7751,7 +7752,7 @@
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "requires": {
-                "abbrev": "1.0.9"
+                "abbrev": "1"
             }
         },
         "normalize-package-data": {
@@ -7760,10 +7761,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -7784,10 +7785,10 @@
             "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "prepend-http": "1.0.4",
-                "query-string": "4.3.4",
-                "sort-keys": "1.1.2"
+                "object-assign": "^4.0.1",
+                "prepend-http": "^1.0.0",
+                "query-string": "^4.1.0",
+                "sort-keys": "^1.0.0"
             }
         },
         "npm-run-path": {
@@ -7796,7 +7797,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "npmconf": {
@@ -7804,15 +7805,15 @@
             "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.3.tgz",
             "integrity": "sha512-iTK+HI68GceCoGOHAQiJ/ik1iDfI7S+cgyG8A+PP18IU3X83kRhQIRhAUNj4Bp2JMx6Zrt5kCiozYa9uGWTjhA==",
             "requires": {
-                "config-chain": "1.1.11",
-                "inherits": "2.0.3",
-                "ini": "1.3.5",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "once": "1.3.3",
-                "osenv": "0.1.0",
-                "safe-buffer": "5.1.2",
-                "semver": "4.3.6",
+                "config-chain": "~1.1.8",
+                "inherits": "~2.0.0",
+                "ini": "^1.2.0",
+                "mkdirp": "^0.5.0",
+                "nopt": "~3.0.1",
+                "once": "~1.3.0",
+                "osenv": "^0.1.0",
+                "safe-buffer": "^5.1.1",
+                "semver": "2 || 3 || 4",
                 "uid-number": "0.0.5"
             },
             "dependencies": {
@@ -7821,7 +7822,7 @@
                     "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "semver": {
@@ -7837,7 +7838,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "num2fraction": {
@@ -7874,9 +7875,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -7885,7 +7886,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -7908,7 +7909,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.getownpropertydescriptors": {
@@ -7917,8 +7918,8 @@
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
             }
         },
         "object.omit": {
@@ -7927,8 +7928,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -7937,7 +7938,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "object.values": {
@@ -7946,10 +7947,10 @@
             "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0",
-                "function-bind": "1.1.1",
-                "has": "1.0.1"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.6.1",
+                "function-bind": "^1.1.0",
+                "has": "^1.0.1"
             }
         },
         "on-finished": {
@@ -7966,7 +7967,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -7975,7 +7976,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "opn": {
@@ -7988,8 +7989,8 @@
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.2"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             }
         },
         "optionator": {
@@ -7998,12 +7999,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             },
             "dependencies": {
                 "deep-is": {
@@ -8026,10 +8027,10 @@
             "integrity": "sha1-iERYIVs6XUCXWSKF+TMhu3p54uU=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-spinners": "1.3.1",
-                "log-symbols": "2.2.0"
+                "chalk": "^2.1.0",
+                "cli-cursor": "^2.1.0",
+                "cli-spinners": "^1.0.1",
+                "log-symbols": "^2.1.0"
             }
         },
         "os-browserify": {
@@ -8050,9 +8051,9 @@
             "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
             "dev": true,
             "requires": {
-                "execa": "0.7.0",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
             },
             "dependencies": {
                 "execa": {
@@ -8061,13 +8062,13 @@
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 }
             }
@@ -8077,8 +8078,8 @@
             "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
             "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
             "requires": {
-                "osx-release": "1.1.0",
-                "win-release": "1.1.1"
+                "osx-release": "^1.0.0",
+                "win-release": "^1.0.0"
             }
         },
         "os-tmpdir": {
@@ -8097,7 +8098,7 @@
             "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
             "integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=",
             "requires": {
-                "minimist": "1.2.0"
+                "minimist": "^1.1.0"
             },
             "dependencies": {
                 "minimist": {
@@ -8119,7 +8120,7 @@
             "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
             "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -8128,7 +8129,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.2.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-throttler": {
@@ -8136,7 +8137,7 @@
             "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.0.tgz",
             "integrity": "sha1-GxaQeULDM+bx3eq8s0eSBLjEF8Q=",
             "requires": {
-                "q": "0.9.7"
+                "q": "~0.9.2"
             },
             "dependencies": {
                 "q": {
@@ -8157,8 +8158,8 @@
             "resolved": "https://registry.npmjs.org/package-json/-/package-json-0.2.0.tgz",
             "integrity": "sha1-Axbhd7jrFJmF009wa0pVQ7J0vsU=",
             "requires": {
-                "got": "0.3.0",
-                "registry-url": "0.1.1"
+                "got": "^0.3.0",
+                "registry-url": "^0.1.0"
             }
         },
         "pako": {
@@ -8173,56 +8174,56 @@
             "integrity": "sha512-QGLn4gjyFyDiNGa7DEfHxRmMXlWPiZApEzVdbnKYX5o3mIMCQl7Cwef9jTuz0vtPA8xCJ8ejgk8eN0zdBpEbzg==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-core": "6.26.3",
-                "babel-generator": "6.26.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-plugin-transform-react-jsx": "6.24.1",
-                "babel-preset-env": "1.7.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "babylon-walk": "1.0.2",
-                "browserslist": "3.2.8",
-                "chalk": "2.4.1",
-                "chokidar": "2.0.3",
-                "command-exists": "1.2.6",
-                "commander": "2.15.1",
-                "cross-spawn": "6.0.5",
-                "cssnano": "3.10.0",
-                "deasync": "0.1.13",
-                "dotenv": "5.0.1",
-                "filesize": "3.6.1",
-                "get-port": "3.2.0",
-                "glob": "7.1.2",
-                "grapheme-breaker": "0.3.2",
-                "htmlnano": "0.1.9",
-                "is-url": "1.2.4",
-                "js-yaml": "3.12.0",
-                "json5": "1.0.1",
-                "micromatch": "3.1.10",
-                "mkdirp": "0.5.1",
-                "node-forge": "0.7.5",
-                "node-libs-browser": "2.1.0",
-                "opn": "5.3.0",
-                "physical-cpu-count": "2.0.0",
-                "postcss": "6.0.22",
-                "postcss-value-parser": "3.3.0",
-                "posthtml": "0.11.3",
-                "posthtml-parser": "0.4.1",
-                "posthtml-render": "1.1.4",
-                "resolve": "1.7.1",
-                "semver": "5.5.0",
-                "serialize-to-js": "1.2.1",
-                "serve-static": "1.13.2",
+                "babel-code-frame": "^6.26.0",
+                "babel-core": "^6.25.0",
+                "babel-generator": "^6.25.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+                "babel-plugin-transform-react-jsx": "^6.24.1",
+                "babel-preset-env": "^1.6.1",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.17.4",
+                "babylon-walk": "^1.0.2",
+                "browserslist": "^3.2.6",
+                "chalk": "^2.1.0",
+                "chokidar": "^2.0.3",
+                "command-exists": "^1.2.6",
+                "commander": "^2.11.0",
+                "cross-spawn": "^6.0.4",
+                "cssnano": "^3.10.0",
+                "deasync": "^0.1.12",
+                "dotenv": "^5.0.0",
+                "filesize": "^3.6.0",
+                "get-port": "^3.2.0",
+                "glob": "^7.1.2",
+                "grapheme-breaker": "^0.3.2",
+                "htmlnano": "^0.1.9",
+                "is-url": "^1.2.2",
+                "js-yaml": "^3.10.0",
+                "json5": "^1.0.1",
+                "micromatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "node-forge": "^0.7.1",
+                "node-libs-browser": "^2.0.0",
+                "opn": "^5.1.0",
+                "physical-cpu-count": "^2.0.0",
+                "postcss": "^6.0.19",
+                "postcss-value-parser": "^3.3.0",
+                "posthtml": "^0.11.2",
+                "posthtml-parser": "^0.4.0",
+                "posthtml-render": "^1.1.3",
+                "resolve": "^1.4.0",
+                "semver": "^5.4.1",
+                "serialize-to-js": "^1.1.1",
+                "serve-static": "^1.12.4",
                 "source-map": "0.6.1",
-                "strip-ansi": "4.0.0",
-                "toml": "2.3.3",
-                "tomlify-j0.4": "3.0.0",
-                "uglify-es": "3.3.9",
-                "v8-compile-cache": "2.0.0",
-                "ws": "5.2.0"
+                "strip-ansi": "^4.0.0",
+                "toml": "^2.3.3",
+                "tomlify-j0.4": "^3.0.0",
+                "uglify-es": "^3.2.1",
+                "v8-compile-cache": "^2.0.0",
+                "ws": "^5.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -8237,11 +8238,11 @@
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.4",
-                        "path-key": "2.0.1",
-                        "semver": "5.5.0",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.0"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "esprima": {
@@ -8256,8 +8257,8 @@
                     "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "4.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "json5": {
@@ -8266,7 +8267,7 @@
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {
-                        "minimist": "1.2.0"
+                        "minimist": "^1.2.0"
                     }
                 },
                 "kind-of": {
@@ -8281,19 +8282,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "minimist": {
@@ -8308,7 +8309,7 @@
                     "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
                     "dev": true,
                     "requires": {
-                        "is-wsl": "1.1.0"
+                        "is-wsl": "^1.1.0"
                     }
                 },
                 "resolve": {
@@ -8317,7 +8318,7 @@
                     "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "1.0.5"
+                        "path-parse": "^1.0.5"
                     }
                 },
                 "source-map": {
@@ -8332,7 +8333,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "uglify-es": {
@@ -8341,8 +8342,8 @@
                     "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
                     "dev": true,
                     "requires": {
-                        "commander": "2.13.0",
-                        "source-map": "0.6.1"
+                        "commander": "~2.13.0",
+                        "source-map": "~0.6.1"
                     },
                     "dependencies": {
                         "commander": {
@@ -8359,7 +8360,7 @@
                     "integrity": "sha512-c18dMeW+PEQdDFzkhDsnBAlS4Z8KGStBQQUcQ5mf7Nf689jyGk0594L+i9RaQuf4gog6SvWLJorz2NfSaqxZ7w==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "1.0.0"
+                        "async-limiter": "~1.0.0"
                     }
                 }
             }
@@ -8370,11 +8371,11 @@
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "dev": true,
             "requires": {
-                "asn1.js": "4.10.1",
-                "browserify-aes": "1.2.0",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.16"
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
             }
         },
         "parse-glob": {
@@ -8383,10 +8384,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "parse-json": {
@@ -8395,7 +8396,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -8475,9 +8476,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "pause-stream": {
@@ -8486,7 +8487,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pbkdf2": {
@@ -8495,11 +8496,11 @@
             "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
             "dev": true,
             "requires": {
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "pend": {
@@ -8537,7 +8538,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -8546,7 +8547,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "pluralize": {
@@ -8573,9 +8574,9 @@
             "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "source-map": "0.6.1",
-                "supports-color": "5.4.0"
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
             },
             "dependencies": {
                 "source-map": {
@@ -8592,9 +8593,9 @@
             "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-message-helpers": "2.0.0",
-                "reduce-css-calc": "1.3.0"
+                "postcss": "^5.0.2",
+                "postcss-message-helpers": "^2.0.0",
+                "reduce-css-calc": "^1.2.6"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8609,11 +8610,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -8636,10 +8637,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -8648,7 +8649,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -8659,9 +8660,9 @@
             "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
             "dev": true,
             "requires": {
-                "colormin": "1.1.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "colormin": "^1.0.5",
+                "postcss": "^5.0.13",
+                "postcss-value-parser": "^3.2.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8676,11 +8677,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -8703,10 +8704,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -8715,7 +8716,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -8726,8 +8727,8 @@
             "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.11",
+                "postcss-value-parser": "^3.1.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8742,11 +8743,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -8769,10 +8770,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -8781,7 +8782,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -8792,7 +8793,7 @@
             "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8807,11 +8808,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -8834,10 +8835,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -8846,7 +8847,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -8857,7 +8858,7 @@
             "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8872,11 +8873,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -8899,10 +8900,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -8911,7 +8912,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -8922,7 +8923,7 @@
             "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8937,11 +8938,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -8964,10 +8965,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -8976,7 +8977,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -8987,7 +8988,7 @@
             "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.16"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9002,11 +9003,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9029,10 +9030,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9041,7 +9042,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9052,8 +9053,8 @@
             "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "postcss": "^5.0.14",
+                "uniqs": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9068,11 +9069,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9095,10 +9096,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9107,7 +9108,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9118,7 +9119,7 @@
             "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9133,11 +9134,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9160,10 +9161,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9172,7 +9173,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9183,9 +9184,9 @@
             "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.10",
+                "postcss-value-parser": "^3.1.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9200,11 +9201,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9227,10 +9228,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9239,7 +9240,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9250,7 +9251,7 @@
             "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9265,11 +9266,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9292,10 +9293,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9304,7 +9305,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9315,11 +9316,11 @@
             "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-api": "1.6.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3",
-                "vendors": "1.0.2"
+                "browserslist": "^1.5.2",
+                "caniuse-api": "^1.5.2",
+                "postcss": "^5.0.4",
+                "postcss-selector-parser": "^2.2.2",
+                "vendors": "^1.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9334,8 +9335,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000849",
-                        "electron-to-chromium": "1.3.48"
+                        "caniuse-db": "^1.0.30000639",
+                        "electron-to-chromium": "^1.2.7"
                     }
                 },
                 "chalk": {
@@ -9344,11 +9345,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9371,10 +9372,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9383,7 +9384,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9400,9 +9401,9 @@
             "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9417,11 +9418,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9444,10 +9445,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9456,7 +9457,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9467,8 +9468,8 @@
             "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.12",
+                "postcss-value-parser": "^3.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9483,11 +9484,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9510,10 +9511,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9522,7 +9523,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9533,10 +9534,10 @@
             "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.2",
+                "postcss-value-parser": "^3.0.2",
+                "uniqs": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9551,11 +9552,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9578,10 +9579,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9590,7 +9591,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9601,10 +9602,10 @@
             "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3"
+                "alphanum-sort": "^1.0.2",
+                "has": "^1.0.1",
+                "postcss": "^5.0.14",
+                "postcss-selector-parser": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9619,11 +9620,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9646,10 +9647,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9658,7 +9659,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9669,7 +9670,7 @@
             "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.5"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9684,11 +9685,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9711,10 +9712,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9723,7 +9724,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9734,10 +9735,10 @@
             "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
             "dev": true,
             "requires": {
-                "is-absolute-url": "2.1.0",
-                "normalize-url": "1.9.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "is-absolute-url": "^2.0.0",
+                "normalize-url": "^1.4.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9752,11 +9753,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9779,10 +9780,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9791,7 +9792,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9802,8 +9803,8 @@
             "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9818,11 +9819,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9845,10 +9846,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9857,7 +9858,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9868,8 +9869,8 @@
             "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9884,11 +9885,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9911,10 +9912,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9923,7 +9924,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9934,7 +9935,7 @@
             "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9949,11 +9950,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -9976,10 +9977,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -9988,7 +9989,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9999,9 +10000,9 @@
             "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.8",
+                "postcss-value-parser": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10016,11 +10017,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -10043,10 +10044,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -10055,7 +10056,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -10066,9 +10067,9 @@
             "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
             "dev": true,
             "requires": {
-                "flatten": "1.0.2",
-                "indexes-of": "1.0.1",
-                "uniq": "1.0.1"
+                "flatten": "^1.0.2",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
             }
         },
         "postcss-svgo": {
@@ -10077,10 +10078,10 @@
             "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
             "dev": true,
             "requires": {
-                "is-svg": "2.1.0",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "svgo": "0.7.2"
+                "is-svg": "^2.0.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3",
+                "svgo": "^0.7.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10095,11 +10096,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -10122,10 +10123,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -10134,7 +10135,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -10145,9 +10146,9 @@
             "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10162,11 +10163,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -10189,10 +10190,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -10201,7 +10202,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -10218,9 +10219,9 @@
             "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10235,11 +10236,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -10262,10 +10263,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "supports-color": {
@@ -10274,7 +10275,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -10285,9 +10286,9 @@
             "integrity": "sha512-quMHnDckt2DQ9lRi6bYLnuyBDnVzK+McHa8+ar4kTdYbWEo/92hREOu3h70ZirudOOp/my2b3r0m5YtxY52yrA==",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "posthtml-parser": "0.3.3",
-                "posthtml-render": "1.1.4"
+                "object-assign": "^4.1.1",
+                "posthtml-parser": "^0.3.3",
+                "posthtml-render": "^1.1.0"
             },
             "dependencies": {
                 "isobject": {
@@ -10305,9 +10306,9 @@
                     "integrity": "sha512-H/Z/yXGwl49A7hYQLV1iQ3h87NE0aZ/PMZhFwhw3lKeCAN+Ti4idrHvVvh4/GX10I7u77aQw+QB4vV5/Lzvv5A==",
                     "dev": true,
                     "requires": {
-                        "htmlparser2": "3.9.2",
-                        "isobject": "2.1.0",
-                        "object-assign": "4.1.1"
+                        "htmlparser2": "^3.9.2",
+                        "isobject": "^2.1.0",
+                        "object-assign": "^4.1.1"
                     }
                 }
             }
@@ -10318,8 +10319,8 @@
             "integrity": "sha512-h7vXIQ21Ikz2w5wPClPakNP6mJeJCK6BT0GpqnQrNNABdR7/TchNlFyryL1Bz6Ww53YWCKkr6tdZuHlxY1AVdQ==",
             "dev": true,
             "requires": {
-                "htmlparser2": "3.9.2",
-                "object-assign": "4.1.1"
+                "htmlparser2": "^3.9.2",
+                "object-assign": "^4.1.1"
             }
         },
         "posthtml-render": {
@@ -10334,13 +10335,13 @@
             "integrity": "sha1-Rlm+AanDMQ9QzlHd+RP+rR18yUA=",
             "dev": true,
             "requires": {
-                "diff-match-patch": "1.0.1",
-                "execa": "0.9.0",
-                "find-up": "2.1.0",
-                "glob": "7.1.2",
-                "ignore": "3.3.8",
-                "mri": "1.1.1",
-                "ora": "1.4.0"
+                "diff-match-patch": "^1.0.0",
+                "execa": "^0.9.0",
+                "find-up": "^2.1.0",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.7",
+                "mri": "^1.1.0",
+                "ora": "^1.3.0"
             }
         },
         "prelude-ls": {
@@ -10373,8 +10374,8 @@
             "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
             "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0",
-                "ansi-styles": "3.2.1"
+                "ansi-regex": "^3.0.0",
+                "ansi-styles": "^3.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -10414,7 +10415,7 @@
             "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
             "integrity": "sha1-c+8gD6gynV06jfQXmJULhkbKRtk=",
             "requires": {
-                "read": "1.0.7"
+                "read": "~1.0.4"
             }
         },
         "proto-list": {
@@ -10434,7 +10435,7 @@
             "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4"
+                "event-stream": "~3.3.0"
             }
         },
         "pseudomap": {
@@ -10449,11 +10450,11 @@
             "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "parse-asn1": "5.1.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1"
             }
         },
         "pump": {
@@ -10461,8 +10462,8 @@
             "resolved": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
             "integrity": "sha1-rl/4wfk+2HrcZTCpdWWxJvWFRUs=",
             "requires": {
-                "end-of-stream": "1.0.0",
-                "once": "1.2.0"
+                "end-of-stream": "~1.0.0",
+                "once": "~1.2.0"
             },
             "dependencies": {
                 "once": {
@@ -10483,14 +10484,14 @@
             "integrity": "sha512-WDnC1FSHTedvRSS8BZB73tPAx2svUCWFdcxVjrybw8pbKOAB1v5S/pW0EamkqQoL1mXiBc+v8lyYjhhzMHIk1Q==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "extract-zip": "1.6.7",
-                "https-proxy-agent": "2.2.1",
-                "mime": "2.3.1",
-                "progress": "2.0.0",
-                "proxy-from-env": "1.0.0",
-                "rimraf": "2.6.2",
-                "ws": "3.3.3"
+                "debug": "^3.1.0",
+                "extract-zip": "^1.6.5",
+                "https-proxy-agent": "^2.1.0",
+                "mime": "^2.0.3",
+                "progress": "^2.0.0",
+                "proxy-from-env": "^1.0.0",
+                "rimraf": "^2.6.1",
+                "ws": "^3.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -10508,9 +10509,9 @@
                     "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "1.0.0",
-                        "safe-buffer": "5.1.2",
-                        "ultron": "1.1.1"
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
                     }
                 }
             }
@@ -10531,8 +10532,8 @@
             "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "strict-uri-encode": "1.1.0"
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
             }
         },
         "querystring": {
@@ -10554,8 +10555,8 @@
             "dev": true,
             "requires": {
                 "buffer-equal": "0.0.1",
-                "minimist": "1.2.0",
-                "through2": "2.0.3"
+                "minimist": "^1.1.3",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "minimist": {
@@ -10572,9 +10573,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -10597,7 +10598,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.0"
             }
         },
         "randomfill": {
@@ -10606,8 +10607,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "2.0.6",
-                "safe-buffer": "5.1.2"
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
             }
         },
         "range-parser": {
@@ -10622,10 +10623,10 @@
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             },
             "dependencies": {
                 "deep-extend": {
@@ -10647,7 +10648,7 @@
             "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
             }
         },
         "read-pkg": {
@@ -10656,9 +10657,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -10667,8 +10668,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -10677,8 +10678,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-exists": {
@@ -10687,7 +10688,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 }
             }
@@ -10698,13 +10699,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
@@ -10713,10 +10714,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.6",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "readline2": {
@@ -10725,7 +10726,7 @@
             "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
             "requires": {
                 "mute-stream": "0.0.4",
-                "strip-ansi": "2.0.1"
+                "strip-ansi": "^2.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -10743,7 +10744,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                     "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
                     "requires": {
-                        "ansi-regex": "1.1.1"
+                        "ansi-regex": "^1.0.0"
                     }
                 }
             }
@@ -10754,7 +10755,7 @@
             "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
             "dev": true,
             "requires": {
-                "util.promisify": "1.0.0"
+                "util.promisify": "^1.0.0"
             }
         },
         "redeyed": {
@@ -10762,7 +10763,7 @@
             "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
             "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
             "requires": {
-                "esprima": "1.0.4"
+                "esprima": "~1.0.4"
             },
             "dependencies": {
                 "esprima": {
@@ -10778,9 +10779,9 @@
             "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2",
-                "math-expression-evaluator": "1.2.17",
-                "reduce-function-call": "1.0.2"
+                "balanced-match": "^0.4.2",
+                "math-expression-evaluator": "^1.2.14",
+                "reduce-function-call": "^1.0.1"
             },
             "dependencies": {
                 "balanced-match": {
@@ -10797,7 +10798,7 @@
             "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2"
+                "balanced-match": "^0.4.2"
             },
             "dependencies": {
                 "balanced-match": {
@@ -10826,9 +10827,9 @@
             "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "private": "0.1.8"
+                "babel-runtime": "^6.18.0",
+                "babel-types": "^6.19.0",
+                "private": "^0.1.6"
             }
         },
         "regex-cache": {
@@ -10837,7 +10838,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -10846,8 +10847,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regexpp": {
@@ -10862,9 +10863,9 @@
             "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
             "dev": true,
             "requires": {
-                "regenerate": "1.4.0",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
             }
         },
         "registry-auth-token": {
@@ -10873,8 +10874,8 @@
             "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
             "dev": true,
             "requires": {
-                "rc": "1.2.8",
-                "safe-buffer": "5.1.2"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "registry-url": {
@@ -10882,7 +10883,7 @@
             "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
             "integrity": "sha1-FzlCe4GxELMCSCocfNcn/8yC1b4=",
             "requires": {
-                "npmconf": "2.1.3"
+                "npmconf": "^2.0.1"
             }
         },
         "regjsgen": {
@@ -10897,7 +10898,7 @@
             "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
             "dev": true,
             "requires": {
-                "jsesc": "0.5.0"
+                "jsesc": "~0.5.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -10932,7 +10933,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "replace-ext": {
@@ -10946,26 +10947,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             }
         },
         "request-progress": {
@@ -10973,7 +10974,7 @@
             "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.0.tgz",
             "integrity": "sha1-vfIGK/wZfF1JJQDUTLOv94ZbSS4=",
             "requires": {
-                "throttleit": "0.0.2"
+                "throttleit": "~0.0.2"
             }
         },
         "request-promise-core": {
@@ -10982,7 +10983,7 @@
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.13.1"
             }
         },
         "request-promise-native": {
@@ -10992,8 +10993,8 @@
             "dev": true,
             "requires": {
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.4"
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.3"
             }
         },
         "request-replay": {
@@ -11001,7 +11002,7 @@
             "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
             "integrity": "sha1-m2k6XRGLOfXFlurV7ZGiZEQFf2A=",
             "requires": {
-                "retry": "0.6.0"
+                "retry": "~0.6.0"
             }
         },
         "require-directory": {
@@ -11022,8 +11023,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             }
         },
         "resolve": {
@@ -11038,7 +11039,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "3.0.0"
+                "resolve-from": "^3.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -11055,8 +11056,8 @@
             "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "1.2.2",
-                "global-modules": "0.2.3"
+                "expand-tilde": "^1.2.2",
+                "global-modules": "^0.2.3"
             }
         },
         "resolve-from": {
@@ -11077,8 +11078,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "ret": {
@@ -11099,7 +11100,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -11107,7 +11108,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "ripemd160": {
@@ -11116,8 +11117,8 @@
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "rsvp": {
@@ -11132,7 +11133,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "rx": {
@@ -11152,7 +11153,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "4.0.8"
+                "rx-lite": "*"
             }
         },
         "safe-buffer": {
@@ -11166,7 +11167,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -11180,7 +11181,7 @@
             "integrity": "sha512-nDwXOhiheoaBT6op02n8wzsshjLXHhh4YAeqsDEoVmy1k2+lGv/ENLsGaWqkaKArUkUx48VO12/ZPa3sI/OEqQ==",
             "dev": true,
             "requires": {
-                "clones": "1.1.0"
+                "clones": "^1.1.0"
             }
         },
         "sane": {
@@ -11189,15 +11190,15 @@
             "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "capture-exit": "1.2.0",
-                "exec-sh": "0.2.1",
-                "fb-watchman": "2.0.0",
-                "fsevents": "1.2.4",
-                "micromatch": "3.1.10",
-                "minimist": "1.2.0",
-                "walker": "1.0.7",
-                "watch": "0.18.0"
+                "anymatch": "^2.0.0",
+                "capture-exit": "^1.2.0",
+                "exec-sh": "^0.2.0",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^1.2.3",
+                "micromatch": "^3.1.4",
+                "minimist": "^1.1.1",
+                "walker": "~1.0.5",
+                "watch": "~0.18.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -11212,19 +11213,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "minimist": {
@@ -11251,7 +11252,7 @@
             "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-0.1.0.tgz",
             "integrity": "sha1-T2BXyj66I8xIS1H2Sq+IsTGjhV0=",
             "requires": {
-                "semver": "2.3.2"
+                "semver": "^2.2.1"
             },
             "dependencies": {
                 "semver": {
@@ -11268,18 +11269,18 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.6.3",
+                "http-errors": "~1.6.2",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.4.0"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.4.0"
             },
             "dependencies": {
                 "mime": {
@@ -11296,8 +11297,8 @@
             "integrity": "sha512-TK6d30GNkOLeFDPuP6Jfy1Q1V31GxzppYTt2lzr8KWmIUKomFj+260QP5o4AhHLu0pr6urgyS8i/Z1PqurjBoA==",
             "dev": true,
             "requires": {
-                "js-beautify": "1.7.5",
-                "safer-eval": "1.2.3"
+                "js-beautify": "^1.7.5",
+                "safer-eval": "^1.2.3"
             }
         },
         "serve": {
@@ -11320,10 +11321,10 @@
                     "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0",
+                        "uri-js": "^4.2.1"
                     }
                 },
                 "fast-deep-equal": {
@@ -11356,9 +11357,9 @@
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "dev": true,
             "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
                 "send": "0.16.2"
             }
         },
@@ -11374,7 +11375,7 @@
             "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
             "dev": true,
             "requires": {
-                "to-object-path": "0.3.0"
+                "to-object-path": "^0.3.0"
             }
         },
         "set-immediate-shim": {
@@ -11389,10 +11390,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -11401,7 +11402,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -11424,8 +11425,8 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "shallow-copy": {
@@ -11440,7 +11441,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -11454,10 +11455,10 @@
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
             "integrity": "sha1-lSxE4LHtkBPvU5WBecxkPod3Rms=",
             "requires": {
-                "array-filter": "0.0.1",
-                "array-map": "0.0.0",
-                "array-reduce": "0.0.0",
-                "jsonify": "0.0.0"
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
             }
         },
         "shellwords": {
@@ -11488,7 +11489,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "is-fullwidth-code-point": "^2.0.0"
             }
         },
         "snapdragon": {
@@ -11497,14 +11498,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -11513,7 +11514,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -11522,7 +11523,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -11533,9 +11534,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -11544,7 +11545,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -11553,7 +11554,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -11562,7 +11563,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -11571,9 +11572,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "kind-of": {
@@ -11590,7 +11591,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             }
         },
         "sntp": {
@@ -11598,7 +11599,7 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
             "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
             "requires": {
-                "hoek": "0.9.1"
+                "hoek": "0.9.x"
             }
         },
         "sort-keys": {
@@ -11607,7 +11608,7 @@
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
             "requires": {
-                "is-plain-obj": "1.1.0"
+                "is-plain-obj": "^1.0.0"
             }
         },
         "source-map": {
@@ -11622,11 +11623,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.1",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -11635,7 +11636,7 @@
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
             }
         },
         "source-map-url": {
@@ -11650,10 +11651,10 @@
             "integrity": "sha1-0gIEA9xe9y7Kw/+rm0L6Fq6RdfU=",
             "dev": true,
             "requires": {
-                "exit": "0.1.2",
-                "signal-exit": "3.0.2",
-                "terminate": "2.1.0",
-                "wait-port": "0.2.2"
+                "exit": "^0.1.2",
+                "signal-exit": "^3.0.2",
+                "terminate": "^2.1.0",
+                "wait-port": "^0.2.2"
             }
         },
         "spdx-correct": {
@@ -11662,8 +11663,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -11678,8 +11679,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -11694,7 +11695,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -11703,7 +11704,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -11716,15 +11717,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stable": {
@@ -11745,7 +11746,7 @@
             "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
             "dev": true,
             "requires": {
-                "escodegen": "1.9.1"
+                "escodegen": "^1.8.1"
             }
         },
         "static-extend": {
@@ -11754,8 +11755,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -11764,7 +11765,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -11775,20 +11776,20 @@
             "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
             "dev": true,
             "requires": {
-                "concat-stream": "1.6.2",
-                "convert-source-map": "1.5.1",
-                "duplexer2": "0.1.4",
-                "escodegen": "1.9.1",
-                "falafel": "2.1.0",
-                "has": "1.0.1",
-                "magic-string": "0.22.5",
+                "concat-stream": "~1.6.0",
+                "convert-source-map": "^1.5.1",
+                "duplexer2": "~0.1.4",
+                "escodegen": "~1.9.0",
+                "falafel": "^2.1.0",
+                "has": "^1.0.1",
+                "magic-string": "^0.22.4",
                 "merge-source-map": "1.0.4",
-                "object-inspect": "1.4.1",
-                "quote-stream": "1.0.2",
-                "readable-stream": "2.3.6",
-                "shallow-copy": "0.0.1",
-                "static-eval": "2.0.0",
-                "through2": "2.0.3"
+                "object-inspect": "~1.4.0",
+                "quote-stream": "~1.0.2",
+                "readable-stream": "~2.3.3",
+                "shallow-copy": "~0.0.1",
+                "static-eval": "^2.0.0",
+                "through2": "~2.0.3"
             }
         },
         "statuses": {
@@ -11809,8 +11810,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "stream-combiner": {
@@ -11819,7 +11820,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-http": {
@@ -11828,11 +11829,11 @@
             "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.1"
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "strict-uri-encode": {
@@ -11846,7 +11847,7 @@
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
             "integrity": "sha1-qwS7M4Z+50vu1/uJu38InTkngPI=",
             "requires": {
-                "strip-ansi": "0.2.2"
+                "strip-ansi": "^0.2.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -11859,7 +11860,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.2.2.tgz",
                     "integrity": "sha1-hU0pDJgVJfyMOXqRCwJa4tVP/Ag=",
                     "requires": {
-                        "ansi-regex": "0.1.0"
+                        "ansi-regex": "^0.1.0"
                     }
                 }
             }
@@ -11870,8 +11871,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -11886,7 +11887,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -11897,7 +11898,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringify-object": {
@@ -11916,7 +11917,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -11925,7 +11926,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-buffer": {
@@ -11934,8 +11935,8 @@
             "integrity": "sha1-yj3cSRnBP5/d8wsd/xAKmDUki00=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
-                "is-utf8": "0.2.1"
+                "is-buffer": "^1.1.0",
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-string": {
@@ -11974,7 +11975,7 @@
             "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
             "dev": true,
             "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
             }
         },
         "svgo": {
@@ -11983,13 +11984,13 @@
             "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
             "dev": true,
             "requires": {
-                "coa": "1.0.4",
-                "colors": "1.1.2",
-                "csso": "2.3.2",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "sax": "1.2.4",
-                "whet.extend": "0.9.9"
+                "coa": "~1.0.1",
+                "colors": "~1.1.2",
+                "csso": "~2.3.1",
+                "js-yaml": "~3.7.0",
+                "mkdirp": "~0.5.1",
+                "sax": "~1.2.1",
+                "whet.extend": "~0.9.9"
             }
         },
         "symbol-tree": {
@@ -12004,12 +12005,12 @@
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1",
-                "chalk": "2.4.1",
-                "lodash": "4.17.10",
+                "ajv": "^5.2.3",
+                "ajv-keywords": "^2.1.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
                 "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             }
         },
         "tar-fs": {
@@ -12017,9 +12018,9 @@
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.5.2.tgz",
             "integrity": "sha1-D1lCS+fu7kUjIxbjAvZtP26m2z4=",
             "requires": {
-                "mkdirp": "0.5.1",
-                "pump": "0.3.5",
-                "tar-stream": "0.4.7"
+                "mkdirp": "^0.5.0",
+                "pump": "^0.3.5",
+                "tar-stream": "^0.4.6"
             }
         },
         "tar-stream": {
@@ -12027,10 +12028,10 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
             "integrity": "sha1-Hx0s6evHtCdlJDyg6PG3v9oKrc0=",
             "requires": {
-                "bl": "0.9.5",
-                "end-of-stream": "1.0.0",
-                "readable-stream": "1.1.14",
-                "xtend": "4.0.1"
+                "bl": "^0.9.0",
+                "end-of-stream": "^1.0.0",
+                "readable-stream": "^1.0.27-1",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -12043,10 +12044,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -12062,7 +12063,7 @@
             "integrity": "sha1-qH7kJL4BodKPLzAQRQQ6W81nmgU=",
             "dev": true,
             "requires": {
-                "ps-tree": "1.1.0"
+                "ps-tree": "^1.1.0"
             }
         },
         "test-exclude": {
@@ -12071,11 +12072,11 @@
             "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "micromatch": "3.1.10",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "require-main-filename": "1.0.1"
+                "arrify": "^1.0.1",
+                "micromatch": "^3.1.8",
+                "object-assign": "^4.1.0",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -12090,19 +12091,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -12135,8 +12136,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "timers-browserify": {
@@ -12145,7 +12146,7 @@
             "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
             "dev": true,
             "requires": {
-                "setimmediate": "1.0.5"
+                "setimmediate": "^1.0.4"
             }
         },
         "timers-ext": {
@@ -12153,8 +12154,8 @@
             "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.5.tgz",
             "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
             "requires": {
-                "es5-ext": "0.10.45",
-                "next-tick": "1.0.0"
+                "es5-ext": "~0.10.14",
+                "next-tick": "1"
             }
         },
         "tiny-inflate": {
@@ -12169,7 +12170,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "tmpl": {
@@ -12196,14 +12197,14 @@
             "integrity": "sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "file-contents": "0.2.4",
-                "glob-parent": "2.0.0",
-                "is-valid-glob": "0.3.0",
-                "isobject": "2.1.0",
-                "lazy-cache": "2.0.2",
-                "vinyl": "1.2.0"
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "file-contents": "^0.2.4",
+                "glob-parent": "^2.0.0",
+                "is-valid-glob": "^0.3.0",
+                "isobject": "^2.1.0",
+                "lazy-cache": "^2.0.1",
+                "vinyl": "^1.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -12212,7 +12213,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -12221,7 +12222,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "file-contents": {
@@ -12230,13 +12231,13 @@
                     "integrity": "sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "file-stat": "0.1.3",
-                        "graceful-fs": "4.1.11",
-                        "is-buffer": "1.1.6",
-                        "is-utf8": "0.2.1",
-                        "lazy-cache": "0.2.7",
-                        "through2": "2.0.3"
+                        "extend-shallow": "^2.0.0",
+                        "file-stat": "^0.1.0",
+                        "graceful-fs": "^4.1.2",
+                        "is-buffer": "^1.1.0",
+                        "is-utf8": "^0.2.0",
+                        "lazy-cache": "^0.2.3",
+                        "through2": "^2.0.0"
                     },
                     "dependencies": {
                         "lazy-cache": {
@@ -12253,9 +12254,9 @@
                     "integrity": "sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "lazy-cache": "0.2.7",
-                        "through2": "2.0.3"
+                        "graceful-fs": "^4.1.2",
+                        "lazy-cache": "^0.2.3",
+                        "through2": "^2.0.0"
                     },
                     "dependencies": {
                         "lazy-cache": {
@@ -12281,7 +12282,7 @@
                     "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
                     "dev": true,
                     "requires": {
-                        "set-getter": "0.1.0"
+                        "set-getter": "^0.1.0"
                     }
                 }
             }
@@ -12292,7 +12293,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
@@ -12301,10 +12302,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -12313,8 +12314,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "toml": {
@@ -12334,7 +12335,7 @@
             "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
             "integrity": "sha1-plp3d5Xly74SmUmb3EIoH/shtfQ=",
             "requires": {
-                "nopt": "1.0.10"
+                "nopt": "~1.0.10"
             },
             "dependencies": {
                 "nopt": {
@@ -12342,7 +12343,7 @@
                     "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                     "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
                     "requires": {
-                        "abbrev": "1.0.9"
+                        "abbrev": "1"
                     }
                 }
             }
@@ -12352,7 +12353,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "toxic": {
@@ -12361,7 +12362,7 @@
             "integrity": "sha1-8RVNi2rCGHWslDqfdAjfLf4WTqI=",
             "dev": true,
             "requires": {
-                "lodash": "2.4.2"
+                "lodash": "^2.4.1"
             },
             "dependencies": {
                 "lodash": {
@@ -12378,7 +12379,7 @@
             "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -12411,7 +12412,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -12426,7 +12427,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "typedarray": {
@@ -12441,9 +12442,9 @@
             "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
             "optional": true,
             "requires": {
-                "async": "0.2.10",
-                "optimist": "0.3.7",
-                "source-map": "0.1.43"
+                "async": "~0.2.6",
+                "optimist": "~0.3.5",
+                "source-map": "~0.1.7"
             },
             "dependencies": {
                 "optimist": {
@@ -12452,7 +12453,7 @@
                     "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
                     "optional": true,
                     "requires": {
-                        "wordwrap": "0.0.2"
+                        "wordwrap": "~0.0.2"
                     }
                 },
                 "source-map": {
@@ -12461,7 +12462,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "optional": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -12496,8 +12497,8 @@
             "integrity": "sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=",
             "dev": true,
             "requires": {
-                "pako": "0.2.9",
-                "tiny-inflate": "1.0.2"
+                "pako": "^0.2.5",
+                "tiny-inflate": "^1.0.0"
             }
         },
         "union-value": {
@@ -12506,10 +12507,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -12518,7 +12519,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -12527,10 +12528,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -12559,8 +12560,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -12569,9 +12570,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -12615,7 +12616,7 @@
                     "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                     "dev": true,
                     "requires": {
-                        "rc": "1.2.8"
+                        "rc": "^1.0.1"
                     }
                 }
             }
@@ -12625,11 +12626,11 @@
             "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.0.tgz",
             "integrity": "sha1-oBDJKK3PAgkLjgzn/vb7Cnysw0o=",
             "requires": {
-                "chalk": "0.5.1",
-                "configstore": "0.3.2",
-                "latest-version": "0.2.0",
-                "semver-diff": "0.1.0",
-                "string-length": "0.1.2"
+                "chalk": "^0.5.0",
+                "configstore": "^0.3.0",
+                "latest-version": "^0.2.0",
+                "semver-diff": "^0.1.0",
+                "string-length": "^0.1.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -12647,11 +12648,11 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                     "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
                     "requires": {
-                        "ansi-styles": "1.1.0",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "0.1.0",
-                        "strip-ansi": "0.3.0",
-                        "supports-color": "0.2.0"
+                        "ansi-styles": "^1.1.0",
+                        "escape-string-regexp": "^1.0.0",
+                        "has-ansi": "^0.1.0",
+                        "strip-ansi": "^0.3.0",
+                        "supports-color": "^0.2.0"
                     }
                 },
                 "has-ansi": {
@@ -12659,7 +12660,7 @@
                     "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                     "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.0"
                     }
                 },
                 "strip-ansi": {
@@ -12667,7 +12668,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                     "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.1"
                     }
                 },
                 "supports-color": {
@@ -12683,7 +12684,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -12724,7 +12725,7 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -12761,8 +12762,8 @@
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "object.getownpropertydescriptors": "2.0.3"
+                "define-properties": "^1.1.2",
+                "object.getownpropertydescriptors": "^2.0.3"
             }
         },
         "uuid": {
@@ -12777,7 +12778,8 @@
             "dev": true
         },
         "v86": {
-            "version": "github:humphd/v86#84086ae0998ff1fb64dc606a1b7d4cad91ebc735"
+            "version": "github:humphd/v86#9fd5965dc0f597981a28aa60c229e0ad28f1b302",
+            "from": "github:humphd/v86#9fd5965d"
         },
         "validate-npm-package-license": {
             "version": "3.0.3",
@@ -12785,8 +12787,8 @@
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "vendors": {
@@ -12800,9 +12802,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vinyl": {
@@ -12811,8 +12813,8 @@
             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -12837,7 +12839,7 @@
             "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
             "dev": true,
             "requires": {
-                "browser-process-hrtime": "0.1.2"
+                "browser-process-hrtime": "^0.1.2"
             }
         },
         "wait-port": {
@@ -12846,9 +12848,9 @@
             "integrity": "sha1-1RpJHkhKF791qUfnEaLwErTm8uM=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.15.1",
-                "debug": "2.6.9"
+                "chalk": "^1.1.3",
+                "commander": "^2.9.0",
+                "debug": "^2.6.6"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12863,11 +12865,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -12884,7 +12886,7 @@
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
             "dev": true,
             "requires": {
-                "makeerror": "1.0.11"
+                "makeerror": "1.0.x"
             }
         },
         "watch": {
@@ -12893,8 +12895,8 @@
             "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
             "dev": true,
             "requires": {
-                "exec-sh": "0.2.1",
-                "minimist": "1.2.0"
+                "exec-sh": "^0.2.0",
+                "minimist": "^1.2.0"
             },
             "dependencies": {
                 "minimist": {
@@ -12932,9 +12934,9 @@
             "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
             "dev": true,
             "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
             }
         },
         "whet.extend": {
@@ -12949,7 +12951,7 @@
             "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -12963,7 +12965,7 @@
             "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
             "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.0.1"
             }
         },
         "window-size": {
@@ -12984,8 +12986,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -12994,7 +12996,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -13003,9 +13005,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 }
             }
@@ -13021,7 +13023,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "write-file-atomic": {
@@ -13030,9 +13032,9 @@
             "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "signal-exit": "3.0.2"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
             }
         },
         "ws": {
@@ -13041,8 +13043,8 @@
             "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
             "dev": true,
             "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.2"
+                "async-limiter": "~1.0.0",
+                "safe-buffer": "~5.1.0"
             }
         },
         "xdg-basedir": {
@@ -13050,7 +13052,7 @@
             "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
             "integrity": "sha1-FP+PY6T9vLBdW27qIrNvMDO58E4=",
             "requires": {
-                "user-home": "1.1.1"
+                "user-home": "^1.0.0"
             }
         },
         "xml-name-validator": {
@@ -13087,18 +13089,18 @@
             "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
             "dev": true,
             "requires": {
-                "cliui": "4.1.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "9.0.2"
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -13113,9 +13115,9 @@
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -13124,7 +13126,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -13135,7 +13137,7 @@
             "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
             "dev": true,
             "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -13152,7 +13154,7 @@
             "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
             "dev": true,
             "requires": {
-                "fd-slicer": "1.0.1"
+                "fd-slicer": "~1.0.1"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
         "predownload-vm": "npm run build-server",
         "download-vm": "node tools/download-vm.js",
         "prebuild-terminal": "npm run download-vm",
-        "build-terminal":
-            "parcel build src/terminal/index.html --public-url /terminal --out-dir dist/terminal",
+        "build-terminal": "parcel build src/terminal/index.html --public-url /terminal --out-dir dist/terminal",
         "eslint": "eslint --fix .",
         "check-eslint": "eslint .",
         "travis": "npm run test",
@@ -37,9 +36,9 @@
     "homepage": "https://github.com/humphd/next#readme",
     "dependencies": {
         "dexie": "^2.0.4",
-        "filer": "humphd/filer#9p-filer",
+        "filer": "humphd/filer#a3bfd5d",
         "mime-types": "^2.1.18",
-        "v86": "humphd/v86#filer-9p-lastknowngood",
+        "v86": "humphd/v86#9fd5965d",
         "xterm": "^3.4.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Travis is failing a build I think because I rebased my v86 dep and the cached git sha is gone.  This will hopefully force it to use the right one vs branch names.  I've also corrected how we cache node deps.