### PR TITLE
Update v86 module, fix how we import V86Starter and pass Filer objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
         "predownload-vm": "npm run build-server",
         "download-vm": "node tools/download-vm.js",
         "prebuild-terminal": "npm run download-vm",
-        "build-terminal":
-            "parcel build src/terminal/index.html --public-url /terminal --out-dir dist/terminal",
+        "build-terminal": "parcel build src/terminal/index.html --public-url /terminal --out-dir dist/terminal",
         "eslint": "eslint --fix .",
         "check-eslint": "eslint .",
         "travis": "npm run test",
@@ -39,7 +38,7 @@
         "dexie": "^2.0.4",
         "filer": "humphd/filer#9p-filer",
         "mime-types": "^2.1.18",
-        "v86": "humphd/v86#filer-9p-lastknowngood",
+        "v86": "humphd/v86#0324c7c",
         "xterm": "^3.4.1"
     },
     "devDependencies": {

--- a/src/terminal/config.js
+++ b/src/terminal/config.js
@@ -1,3 +1,7 @@
+import fs from '../lib/fs';
+import Path from '../lib/path';
+import Buffer from '../lib/buffer';
+
 export const stateUrl = 'bin/vm-state.bin';
 export const vmStateCache = 'vm-state';
 
@@ -39,12 +43,17 @@ export const defaultEmulatorOptions = {
     cdrom: {
         url: 'bin/v86-linux.iso',
     },
+    // Pass our filesystem instance objects in to the Plan 9 Virtio code.
     filesystem: {
-        // XXX: I need this so v86 starts with a P9 filesystem
+        fs,
+        sh: new fs.Shell(),
+        Path,
+        Buffer,
     },
     // Mouse disabled, undo if you want to interact with the screen
     disable_mouse: true,
     // Keyboard disabled, undo if you want to type in screen
     disable_keyboard: true,
+    disable_speaker: true,
     autostart: true,
 };

--- a/src/terminal/vm.js
+++ b/src/terminal/vm.js
@@ -1,13 +1,6 @@
 'use strict';
 
-// XXX: need to use built version, since Parcel throws at runtime otherwise
-import Filer from '../../node_modules/filer/dist/filer';
-// XXX: expose Filer as a global until I get v86 properly built
-window.Filer = Filer;
-
-// XXX: current v86 is exposed on global
-import 'v86';
-
+import { V86Starter } from 'v86';
 import { stateUrl, defaultEmulatorOptions } from './config';
 
 // What our shell prompt looks like, so we can wait on it.
@@ -74,7 +67,7 @@ const coldBoot = async term => {
         term.write('.');
     }, 500);
 
-    const emulator = new window.V86Starter(defaultEmulatorOptions);
+    const emulator = new V86Starter(defaultEmulatorOptions);
     await storeInitialStateOnBoot(emulator, term, timer);
 
     return emulator;
@@ -88,7 +81,7 @@ const warmBoot = term => {
         url: stateUrl,
     };
 
-    const emulator = new window.V86Starter(options);
+    const emulator = new V86Starter(options);
     startTerminal(emulator, term);
 
     return emulator;


### PR DESCRIPTION
Follow-up to #131.  This updates our `v86` to pick up the changes from https://github.com/humphd/v86/commit/0324c7cfefe76391db7ddabc6b612054fda7a8cf, where I refactor how we export and import the modules needed for the filesystem.