### PR TITLE
Fix #129: Add eslint-plugin-promises

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,9 +5,12 @@ env:
   node: true
   worker: true
   jest: true
+plugins:
+  - 'promise'
 extends: 
   - 'eslint:recommended'
   - 'plugin:prettier/recommended'
+  - 'plugin:promise/recommended'
 parserOptions:
   sourceType: module
   ecmaVersion: 2017

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "eslint": "^4.19.1",
         "eslint-config-prettier": "^2.9.0",
         "eslint-plugin-prettier": "^2.6.0",
+        "eslint-plugin-promise": "^3.8.0",
         "expect-puppeteer": "^3.0.1",
         "husky": "^0.14.3",
         "jest": "^23.1.0",


### PR DESCRIPTION
Fixes #129 - this PR introduces [`eslint-plugin-promises`](https://github.com/xjamundx/eslint-plugin-promise#eslint-plugin-promise), an `npm` package that `eslint` utilizes to enforce best practices for [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).

**Note**: This PR will introduce a breaking build, as there are currently the following errors:

**Each then() should return a value or throw**:

* `src/db/drag-drop.js` (lines [`76`](https://github.com/humphd/next/blob/master/src/db/drag-drop.js#L76), [`112`](https://github.com/humphd/next/blob/master/src/db/drag-drop.js#L112), and [`144`](https://github.com/humphd/next/blob/master/src/db/drag-drop.js#L144))

* `src/db/process.js` (line [`29`](https://github.com/humphd/next/blob/master/src/db/process.js#L29))

In addition, there are multiple other warnings that should be addressed in a future PR once this has landed:

<img width="659" alt="screen shot 2018-07-02 at 20 40 22" src="https://user-images.githubusercontent.com/13009507/42192652-321ce81e-7e38-11e8-85dc-793f9fc906eb.png">
